### PR TITLE
Add capability check for asset-aware mode to unity-mcp-ui-layout SKILL

### DIFF
--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -33,6 +33,14 @@ Read the current context before making changes.
 - For UI Toolkit, find the active `UIDocument`, linked `UXML`, linked `USS`, and panel settings before editing styles.
 - If the user provides a layout image and target resolution, treat them as the source spec for composition before creating any objects.
 
+After the initial scene/editor inspection, run a quick capability check before planning the implementation:
+
+- Detect whether `unity-resource-rag` MCP/tools are available.
+- Detect whether an asset catalog or asset index is available.
+- If both are available and the task would benefit from reusing existing assets, switch into an asset-aware mode and look for matching reusable assets before building replacements from scratch.
+- Otherwise, continue in layout-only mode without blocking the task.
+- Make it explicit in your reasoning that missing `unity-resource-rag` support is normal and supported. Treat its absence as an expected environment variation, not as an error condition.
+
 ### 2. Build in Vertical Slices
 
 Do not generate the full interface in one shot.


### PR DESCRIPTION
### Motivation
- Add a quick capability detection step after the initial scene/editor inspection so the skill can prefer asset reuse when `unity-resource-rag` and an asset catalog/index are available, while treating the absence of `unity-resource-rag` as an expected, non-error environment variation.

### Description
- Inserted a capability-check block into `unity-mcp-ui-layout/SKILL.md` that instructs detection of `unity-resource-rag` MCP/tools and an asset catalog/index and to switch to an asset-aware mode when both exist and asset reuse would be beneficial, otherwise continue in layout-only mode without blocking the task.

### Testing
- No automated tests were required for this documentation-only change; the file `unity-mcp-ui-layout/SKILL.md` was updated and the change was committed and verified via `git status`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd0277e714832e9a28b2a3474135df)