### PR TITLE
Add asset-RAG fallback contract to UI layout skill and image-to-layout reference

### DIFF
--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -38,7 +38,9 @@ After the initial scene/editor inspection, run a quick capability check before p
 - Detect whether `unity-resource-rag` MCP/tools are available.
 - Detect whether an asset catalog or asset index is available.
 - If both are available and the task would benefit from reusing existing assets, switch into an asset-aware mode and look for matching reusable assets before building replacements from scratch.
-- Otherwise, continue in layout-only mode without blocking the task.
+- If `unity-resource-rag` is unavailable, continue with image-to-layout translation using the existing layout rules, preserve structure-first execution, use placeholder visuals or existing manually discovered assets, and explicitly state that asset-aware retrieval was skipped.
+- If `unity-resource-rag` is available but retrieval confidence is low, do not force an asset match, keep the layout workflow moving, mark visuals as provisional, and verify structure first.
+- Missing or low-confidence asset-RAG capability is not a hard blocker unless the user explicitly requires asset-index-backed reuse.
 - Make it explicit in your reasoning that missing `unity-resource-rag` support is normal and supported. Treat its absence as an expected environment variation, not as an error condition.
 
 ### 2. Build in Vertical Slices

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -7,7 +7,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 ## Core Guidance
 
 - `layout-checklist.md`
-- `image-to-layout.md`
+- `image-to-layout.md` — includes the asset-RAG fallback contract for when `unity-resource-rag` is unavailable or low-confidence.
 - `mcp-call-recipes.md`
 - `common-failures.md`
 - `review-checks.md`

--- a/unity-mcp-ui-layout/references/image-to-layout.md
+++ b/unity-mcp-ui-layout/references/image-to-layout.md
@@ -17,6 +17,18 @@ Require these inputs when available:
 
 If the image is the only reliable source of truth, use it as the composition reference.
 
+## Asset-RAG Fallback Contract
+
+When image-to-layout work intersects with asset reuse, keep the layout workflow moving even if asset retrieval is incomplete.
+
+- If `unity-resource-rag` is unavailable, continue with image-to-layout translation using the existing layout rules.
+- Preserve structure-first execution: build regions, anchors, and parent containers before spending time on final art selection.
+- Use placeholder visuals or existing manually discovered assets when retrieval support is missing.
+- Explicitly say that asset-aware retrieval was skipped when `unity-resource-rag` is unavailable.
+- If `unity-resource-rag` is available but retrieval confidence is low, do not force an asset match just to claim reuse.
+- Keep the layout workflow moving, mark visuals as provisional, and verify structure first.
+- Never present missing or low-confidence asset-RAG capability as a hard blocker unless the user explicitly requires asset-index-backed reuse.
+
 ## Translation Procedure
 
 ### 1. Segment the image


### PR DESCRIPTION
### Motivation
- Ensure image-to-layout workflows keep moving when `unity-resource-rag` is missing or retrieval confidence is low by defining explicit fallback behavior that preserves structure-first execution and avoids treating missing or low-confidence asset retrieval as a hard blocker.

### Description
- Update `unity-mcp-ui-layout/SKILL.md` to extend the capability-check with explicit rules for when `unity-resource-rag` is unavailable or retrieval confidence is low, including using placeholders, marking visuals provisional, and continuing structure-first layout work.
- Add an `Asset-RAG Fallback Contract` section to `unity-mcp-ui-layout/references/image-to-layout.md` documenting the precise fallback behaviors (continue layout, use placeholder or manually discovered assets, state that asset-aware retrieval was skipped, and avoid forcing low-confidence matches).
- Update `unity-mcp-ui-layout/references/README.md` to reference the new fallback contract so it is discoverable from the core guidance list.

### Testing
- Ran `git diff -- unity-mcp-ui-layout/SKILL.md unity-mcp-ui-layout/references/image-to-layout.md unity-mcp-ui-layout/references/README.md` to validate the inserted changes and confirm the diffs match the intended updates.
- Ran `git status --short` to verify only the intended files were modified and the workspace reflected the changes; both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd033ad3f4832ebe186717b29660b0)