### PR TITLE
Add brief asset-mode disclosure guidance

### DIFF
--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -49,6 +49,9 @@ After the initial scene/editor inspection, run a quick capability check before p
 - If asset-aware mode is warranted and `unity-resource-rag` is available but retrieval confidence is low, do not force an asset match, keep the layout workflow moving, mark visuals as provisional, and verify structure first.
 - Missing or low-confidence asset-RAG capability is not a hard blocker unless the user explicitly requires asset-index-backed reuse.
 - Make it explicit in your reasoning that missing `unity-resource-rag` support is normal and supported. Treat its absence as an expected environment variation, not as an error condition.
+- Keep any mode disclosure brief: one or two lines only.
+- In asset-aware mode, say that existing project assets will be retrieved and reused where confidence is high.
+- In layout-only mode, say that the task will proceed without asset-index-backed retrieval, focus on stable structure first, and use placeholders or directly inspected assets if needed.
 
 ### 2. Build in Vertical Slices
 

--- a/unity-mcp-ui-layout/references/image-to-layout.md
+++ b/unity-mcp-ui-layout/references/image-to-layout.md
@@ -28,6 +28,9 @@ When image-to-layout work intersects with asset reuse, keep the layout workflow 
 - If `unity-resource-rag` is available but retrieval confidence is low, do not force an asset match just to claim reuse.
 - Keep the layout workflow moving, mark visuals as provisional, and verify structure first.
 - Never present missing or low-confidence asset-RAG capability as a hard blocker unless the user explicitly requires asset-index-backed reuse.
+- Keep any asset-mode disclosure to one or two lines.
+- In asset-aware mode, say that existing project assets will be retrieved and reused where confidence is high.
+- In layout-only mode, say that the task will proceed without asset-index-backed retrieval, focus on stable structure first, and use placeholders or directly inspected assets if needed.
 
 ## Translation Procedure
 


### PR DESCRIPTION
### Motivation
- Make the workflow's asset-mode behavior explicit and compact so users see a one- or two-line disclosure describing `asset-aware` vs `layout-only` behavior without bloating the guidance.

### Description
- Added a concise mode-disclosure to `unity-mcp-ui-layout/SKILL.md` and mirrored it in `unity-mcp-ui-layout/references/image-to-layout.md` that states: in `asset-aware` mode existing project assets will be retrieved and reused where confidence is high, and in `layout-only` mode the task will proceed without asset-index-backed retrieval, focus on stable structure first, and use placeholders or directly inspected assets if needed.

### Testing
- Ran `git diff --check`, `git status --short`, and `git rev-parse --short HEAD` as repository checks and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd08c2490c832eb9b25398a0a1a662)