### PR TITLE
기존 프리팹 재사용 판단 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Platform-specific adapters live in:
 - UGUI anchors and `CanvasScaler`
 - HUD, inventory, popup, and mobile safe-area layout rules
 - prefab promotion rules for repeated UI structures
+- reuse/variant/new-base decision rules for existing prefabs
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -58,6 +59,7 @@ Platform-specific adapters live in:
 - UGUI 앵커와 `CanvasScaler` 설정
 - HUD, 인벤토리, 팝업, 모바일 safe area 레이아웃 규칙
 - 반복되는 UI 구조를 프리팹으로 승격하는 규칙
+- 기존 프리팹을 재사용/Variant/신규 생성 중 무엇으로 갈지 판단하는 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -140,6 +140,7 @@ Use screenshots aggressively.
 - Read `references/common-failures.md` when the UI result technically exists but still feels fragile, inconsistent, overfit to one resolution, or structurally wrong.
 - Read `references/image-to-layout.md` when the user provides a mockup, screenshot, wireframe, or other layout image plus a target resolution.
 - Read `references/mcp-call-recipes.md` when you need concrete `unity-mcp` call sequences for discovery, creation, repair, verification, or script-backed UI work.
+- Read `references/existing-prefab-reuse.md` when the project likely already contains a similar reusable UI block and you need to choose reuse, variant, wrapper, or a new base prefab.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.
 - Read `references/review-checks.md` when you need a final quality pass before calling a Unity UI task complete.
 - Read `references/ugui-anchors-canvas-scaler.md` when the target is UGUI or when anchor, pivot, or screen-scaling behavior is causing drift.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -9,6 +9,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `layout-checklist.md`
 - `image-to-layout.md` - includes the asset-RAG fallback contract for when `unity-resource-rag` is unavailable or low-confidence.
 - `mcp-call-recipes.md`
+- `existing-prefab-reuse.md`
 - `prefab-reuse.md`
 - `common-failures.md`
 - `review-checks.md`

--- a/unity-mcp-ui-layout/references/existing-prefab-reuse.md
+++ b/unity-mcp-ui-layout/references/existing-prefab-reuse.md
@@ -1,0 +1,117 @@
+# Existing Prefab Reuse Rules
+
+Use this guide when the project may already contain a similar UI prefab and the safer choice might be reuse, variant creation, or a small extension instead of building a new asset from scratch.
+
+## Goal
+
+Prefer stable reuse over duplication by checking whether a similar project prefab already exists, deciding whether it should be reused directly, turned into a variant, or replaced by a new base prefab, and keeping that decision explicit.
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A["Need a repeated or reusable UI block"] --> B["Inspect similar project UI and known prefab candidates"]
+    B --> C{"High-confidence existing prefab match?"}
+    C -- "No" --> D["Create a new base prefab"]
+    C -- "Yes" --> E{"Needs only data/content changes?"}
+    E -- "Yes" --> F["Reuse existing prefab directly"]
+    E -- "No" --> G{"Needs visual or behavior variation but same core structure?"}
+    G -- "Yes" --> H["Create a prefab variant or thin wrapper"]
+    G -- "No" --> I{"Base is too coupled, unstable, or misleading?"}
+    I -- "Yes" --> D
+    I -- "No" --> J["Extend carefully and verify impact"]
+```
+
+## Reuse Priority
+
+Prefer this order:
+
+1. reuse an existing stable prefab
+2. create a variant or thin wrapper around it
+3. create a new base prefab
+
+Do not jump to a new prefab first unless the existing candidates are clearly unsuitable.
+
+## Inspect First
+
+Before deciding:
+
+- Look for visually similar widgets already used in the scene or nearby screens.
+- Check whether those widgets are truly prefab-backed reusable assets or only scene-local assemblies.
+- Inspect whether the candidate already covers the same hierarchy, sizing logic, state model, and interaction pattern.
+- Distinguish between data differences and structural differences.
+- Check whether the candidate is already used widely enough that direct edits carry shared risk.
+
+## Reuse Directly When
+
+- The existing prefab already matches the same role and hierarchy.
+- The changes are mostly text, icon, number, state, or small content-level swaps.
+- The current screen wants to stay consistent with other existing screens.
+- Direct reuse reduces duplication without hiding new constraints.
+
+## Prefer a Variant or Wrapper When
+
+- The core structure is the same, but visuals or behavior differ in a controlled way.
+- The base prefab should remain reusable for multiple screens.
+- You need a special style, state, or optional section that should not pollute the base prefab for everyone else.
+- You want to preserve upgrade paths from the base prefab while isolating screen-specific overrides.
+
+## Prefer a New Base Prefab When
+
+- Existing candidates are structurally misleading and would require heavy override work.
+- The candidate has too many unrelated dependencies or brittle assumptions.
+- The new UI pattern is likely to become the clearer shared standard going forward.
+- Forcing reuse would create hidden coupling or make maintenance harder than a clean new base.
+
+## Safe Modification Rules
+
+If an existing prefab is already shared:
+
+- Treat direct edits as high-impact until proven otherwise.
+- Check where else it appears before modifying core hierarchy, spacing ownership, anchors, or component assumptions.
+- Prefer variants, wrappers, or smaller extracted sub-blocks when the requested change is screen-specific.
+- After a base prefab edit, verify the current target plus at least one other known usage.
+
+## Tool Strategy
+
+Use a bounded sequence:
+
+1. Inspect the current scene and similar UI candidates with `editor_state`, `find_gameobjects`, and any available asset-aware retrieval.
+2. If asset-aware mode is active, look for similar reusable prefabs before creating replacements.
+3. Compare the best candidate against the requested role: direct reuse, variant, wrapper, or new base.
+4. Use `manage_prefabs` for prefab creation or modification.
+5. Use `manage_gameobject` and `manage_components` only for scene placement or small candidate normalization.
+6. If behavior components are involved, update them with `manage_script`, then run `refresh_unity` and inspect `read_console`.
+7. Verify the target screen and one shared usage path with `manage_camera` when direct reuse or base edits were chosen.
+
+## UGUI Rules
+
+- Good reuse candidates: item slot, reward card, stat row, quest row, party plate, shared popup button group, shop entry, tab item, badge stack.
+- Keep screen-edge placement in the parent container even when reusing an existing prefab.
+- If the parent uses a `LayoutGroup`, preserve parent ownership of repeated placement.
+- Do not push screen-specific offsets back into the reused base prefab just to solve one screen.
+- If the base prefab already mixes too many responsibilities, prefer extracting a smaller reusable sub-block before adding more overrides.
+
+## UI Toolkit Equivalent
+
+For UI Toolkit, apply the same decision logic to reusable `UXML` structures, `VisualElement` blocks, or shared `USS`-class-driven patterns:
+
+- reuse the existing template/class combination when structure already matches
+- create a small variant pattern when the base is still right but needs scoped overrides
+- create a new shared block only when reuse would be misleading or too coupled
+
+## Common Anti-Patterns
+
+- Creating a new prefab without checking whether the project already has the same widget.
+- Editing a shared base prefab for a one-screen request that should have used a variant.
+- Reusing an existing prefab only because the name sounds similar even though the hierarchy or state model is wrong.
+- Overriding so many parts of a base prefab that a clean new base would have been clearer.
+- Fixing one screen by pushing screen-specific anchors or spacing into a widely shared prefab.
+
+## Verification Questions
+
+- Did you inspect existing reusable candidates before deciding to create a new prefab?
+- Is the decision clear: direct reuse, variant/wrapper, or new base?
+- If you reused a shared prefab directly, did you verify another known usage path?
+- If you created a variant, does the base remain clean and generally reusable?
+- If you created a new base prefab, was that actually simpler and safer than forced reuse?

--- a/unity-mcp-ui-layout/references/mcp-call-recipes.md
+++ b/unity-mcp-ui-layout/references/mcp-call-recipes.md
@@ -221,3 +221,32 @@ Verify one base case and one content variant with screenshots.
 - `manage_prefabs`
 - `manage_camera`
 - `read_console`
+
+## 9. Reuse an Existing Project Prefab
+
+Use this when the project may already contain a shared widget and you need to decide between direct reuse, variant creation, or a new base prefab.
+
+### Typical sequence
+
+1. Inspect similar existing UI and candidate prefabs
+2. Compare role, hierarchy, layout ownership, and state model
+3. Decide between direct reuse, variant, wrapper, or new base
+4. Apply the smallest safe prefab change
+5. Verify the target screen and one shared usage path if the base prefab was edited
+
+### Example prompt
+
+```text
+Inspect the project for an existing prefab that already matches this UI block before creating a new one.
+Choose whether to reuse it directly, create a variant, wrap it, or make a new base prefab.
+If you edit a shared prefab, verify the current target and one other known usage with screenshots.
+```
+
+### Common calls
+
+- `find_gameobjects`
+- `manage_prefabs`
+- `manage_gameobject`
+- `manage_components`
+- `manage_camera`
+- `read_console`

--- a/unity-mcp-ui-layout/references/prefab-reuse.md
+++ b/unity-mcp-ui-layout/references/prefab-reuse.md
@@ -2,6 +2,8 @@
 
 Use this guide when the same UI shape appears more than once and should become one reusable prefab or reusable template block instead of repeated manual reconstruction.
 
+If the project may already contain a similar reusable asset, pair this guide with `existing-prefab-reuse.md` before creating a new base prefab.
+
 ## Goal
 
 Stabilize repeated UI work by extracting one reusable structure, keeping screen-level placement outside the prefab where possible, and varying only the parts that truly change.

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -159,3 +159,14 @@ Choose the cleanest shared structure, extract one reusable prefab or template-st
 Only vary data-level content such as text, icon, count, or state per instance.
 Verify that one structural change propagates cleanly across repeated instances.
 ```
+
+## Pattern 15: Reuse Existing Prefab Before Creating a New One
+
+Use when the project may already contain a similar reusable widget.
+
+```text
+Before creating a new prefab, inspect whether the project already contains a reusable UI block for this role.
+Choose explicitly between direct reuse, prefab variant, thin wrapper, or a new base prefab.
+Do not edit a shared base prefab for a one-screen request unless you verify the impact on another known usage.
+Keep screen-level placement in the parent container rather than pushing one-screen offsets into the shared prefab.
+```


### PR DESCRIPTION
## 변경 내용
- 기존 프로젝트 프리팹을 먼저 찾고 재사용/variant/wrapper/신규 base 중 무엇을 선택할지 결정하는 전용 가이드 추가
- 기존 prefab-reuse 문서와 연결 강화
- manage_prefabs 중심의 기존 프리팹 재사용 MCP 호출 레시피 추가
- 반복 구조 프롬프트 패턴에 기존 프리팹 탐색 우선 규칙 추가
- 루트 README와 스킬 참조 인덱스 갱신

## 목적
- 동일 형태 UI를 새 프리팹으로 바로 만들기 전에 기존 자산을 먼저 재사용하도록 유도합니다.
- 공용 프리팹 직접 수정, variant 생성, 신규 base 생성의 선택 기준을 명확히 합니다.
- screen-level 배치 책임과 shared prefab 책임이 섞이지 않도록 합니다.

## PR 관계
- 이 PR은 #7 위에 쌓이는 stacked PR입니다.
- 먼저 #7이 머지되면 base를 main으로 바꿔 머지하면 됩니다.

## 영향 범위
- 문서 전용 변경입니다.
- UGUI 중심 규칙이지만 UI Toolkit의 template-equivalent reuse 판단도 포함합니다.
