### PR TITLE
프리팹 Variant 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Platform-specific adapters live in:
 - HUD, inventory, popup, and mobile safe-area layout rules
 - prefab promotion rules for repeated UI structures
 - reuse/variant/new-base decision rules for existing prefabs
+- prefab variant rules for controlled divergence from a shared base
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -60,6 +61,7 @@ Platform-specific adapters live in:
 - HUD, 인벤토리, 팝업, 모바일 safe area 레이아웃 규칙
 - 반복되는 UI 구조를 프리팹으로 승격하는 규칙
 - 기존 프리팹을 재사용/Variant/신규 생성 중 무엇으로 갈지 판단하는 규칙
+- 공용 base에서 안전하게 분기하는 Prefab Variant 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -141,6 +141,7 @@ Use screenshots aggressively.
 - Read `references/image-to-layout.md` when the user provides a mockup, screenshot, wireframe, or other layout image plus a target resolution.
 - Read `references/mcp-call-recipes.md` when you need concrete `unity-mcp` call sequences for discovery, creation, repair, verification, or script-backed UI work.
 - Read `references/existing-prefab-reuse.md` when the project likely already contains a similar reusable UI block and you need to choose reuse, variant, wrapper, or a new base prefab.
+- Read `references/prefab-variants.md` when one shared base prefab should branch into a controlled family of variants without polluting the base asset.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.
 - Read `references/review-checks.md` when you need a final quality pass before calling a Unity UI task complete.
 - Read `references/ugui-anchors-canvas-scaler.md` when the target is UGUI or when anchor, pivot, or screen-scaling behavior is causing drift.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -10,6 +10,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `image-to-layout.md` - includes the asset-RAG fallback contract for when `unity-resource-rag` is unavailable or low-confidence.
 - `mcp-call-recipes.md`
 - `existing-prefab-reuse.md`
+- `prefab-variants.md`
 - `prefab-reuse.md`
 - `common-failures.md`
 - `review-checks.md`

--- a/unity-mcp-ui-layout/references/existing-prefab-reuse.md
+++ b/unity-mcp-ui-layout/references/existing-prefab-reuse.md
@@ -2,6 +2,8 @@
 
 Use this guide when the project may already contain a similar UI prefab and the safer choice might be reuse, variant creation, or a small extension instead of building a new asset from scratch.
 
+If the best answer is "same base, but scoped divergence", pair this guide with `prefab-variants.md`.
+
 ## Goal
 
 Prefer stable reuse over duplication by checking whether a similar project prefab already exists, deciding whether it should be reused directly, turned into a variant, or replaced by a new base prefab, and keeping that decision explicit.

--- a/unity-mcp-ui-layout/references/mcp-call-recipes.md
+++ b/unity-mcp-ui-layout/references/mcp-call-recipes.md
@@ -250,3 +250,32 @@ If you edit a shared prefab, verify the current target and one other known usage
 - `manage_components`
 - `manage_camera`
 - `read_console`
+
+## 10. Create a Prefab Variant Safely
+
+Use this when an existing base prefab is right, but the current screen needs scoped differences that should not be pushed into the base.
+
+### Typical sequence
+
+1. Inspect the base prefab and the requested differences
+2. Confirm that the change should be a variant rather than direct reuse or a new base
+3. Create or update the prefab variant
+4. Keep screen placement parent-owned and keep overrides local to the variant
+5. Verify the target variant and one related base-family usage
+
+### Example prompt
+
+```text
+Inspect the existing base prefab for this UI block and decide whether the requested differences belong in a prefab variant.
+If so, create a variant that keeps the base contract intact, limits overrides to local visual or optional-content differences, and avoids pushing one-screen placement rules into the asset.
+Verify the target variant and one related base-family usage with screenshots.
+```
+
+### Common calls
+
+- `find_gameobjects`
+- `manage_prefabs`
+- `manage_gameobject`
+- `manage_components`
+- `manage_camera`
+- `read_console`

--- a/unity-mcp-ui-layout/references/prefab-reuse.md
+++ b/unity-mcp-ui-layout/references/prefab-reuse.md
@@ -2,7 +2,7 @@
 
 Use this guide when the same UI shape appears more than once and should become one reusable prefab or reusable template block instead of repeated manual reconstruction.
 
-If the project may already contain a similar reusable asset, pair this guide with `existing-prefab-reuse.md` before creating a new base prefab.
+If the project may already contain a similar reusable asset, pair this guide with `existing-prefab-reuse.md` before creating a new base prefab. If one shared base should branch into controlled visual or behavioral families, also read `prefab-variants.md`.
 
 ## Goal
 

--- a/unity-mcp-ui-layout/references/prefab-variants.md
+++ b/unity-mcp-ui-layout/references/prefab-variants.md
@@ -1,0 +1,118 @@
+# Prefab Variant Rules
+
+Use this guide when an existing base prefab is structurally correct, but the requested UI needs scoped visual, behavioral, or optional-content differences that should not be pushed into the base for every screen.
+
+## Goal
+
+Keep shared prefab families stable by using variants for controlled divergence, limiting overrides to the minimum necessary surface, and avoiding one-screen fixes that pollute the base prefab.
+
+## Variant Decision Flow
+
+```mermaid
+flowchart TD
+    A["Existing base prefab found"] --> B{"Same structure still fits?"}
+    B -- "No" --> C["Use existing-prefab-reuse rules to choose wrapper or new base"]
+    B -- "Yes" --> D{"Only data/content changes?"}
+    D -- "Yes" --> E["Reuse base directly"]
+    D -- "No" --> F{"Visual state, optional section, or scoped behavior difference?"}
+    F -- "Yes" --> G["Create a prefab variant"]
+    F -- "No" --> H{"Too many structural overrides needed?"}
+    H -- "Yes" --> C
+    H -- "No" --> I["Use a thin wrapper or carefully extend base"]
+```
+
+## Use a Variant When
+
+- The base hierarchy still matches the requested role.
+- The screen needs a different visual state, style, rarity frame, emphasis level, or optional child block.
+- The requested differences should stay local to one screen, mode, or feature family.
+- You want inheritance from the base prefab without duplicating the full structure.
+
+## Do Not Use a Variant When
+
+- The requested UI no longer fits the base hierarchy.
+- The variant would override so many properties that the base relationship becomes misleading.
+- The difference is only data-level content and can be handled by normal instance configuration.
+- The change should become the new shared standard for every usage of the base prefab.
+
+## Override Discipline
+
+Prefer overriding in this order:
+
+1. visuals and content defaults
+2. optional child visibility
+3. scoped behavior toggles
+4. local layout details inside the prefab root
+
+Avoid overriding in this order unless truly necessary:
+
+1. screen-edge anchors
+2. parent-owned layout assumptions
+3. shared component contracts
+4. core hierarchy shape that defines the base prefab's meaning
+
+## Safe Variant Rules
+
+- Keep screen-level placement in the parent container, not in the variant.
+- Preserve the base prefab's contract: expected child roles, binding points, component assumptions, and state ownership.
+- Use variants to isolate screen-specific differences, not to quietly fork the base prefab into a second unrelated standard.
+- If a variant needs many structural exceptions, stop and reconsider whether a wrapper or new base prefab is cleaner.
+- After changing the base prefab, verify at least one variant that depends on it.
+- After changing a variant, verify the base still behaves as expected if shared assets or scripts were touched.
+
+## Good Variant Candidates
+
+- common button -> danger button / primary button / reward claim button
+- inventory slot -> selected slot / rare slot / locked slot
+- reward card -> premium reward card / event reward card
+- popup button row -> compact popup row / emphasized confirm row
+- quest row -> tracked quest row / completed quest row
+
+## Poor Variant Candidates
+
+- a layout that moves from list row to card grid and no longer shares the same structure
+- a prefab that now needs different parent layout ownership
+- a screen that requires many unique children unrelated to the original base role
+- a case where only text, icon, and count differ and normal reuse was enough
+
+## Tool Strategy
+
+Use a bounded sequence:
+
+1. Inspect the base prefab and current target usage.
+2. Confirm that the difference is variant-worthy rather than direct reuse or a new base.
+3. Create or update the prefab variant with `manage_prefabs`.
+4. Keep scene placement changes in `manage_gameobject`, not in the variant asset unless the variant root itself needs local layout changes.
+5. If variant-specific behavior depends on scripts or component settings, update them with `manage_script`, then run `refresh_unity` and inspect `read_console`.
+6. Verify the variant in the target screen and verify that the base prefab family still behaves coherently with `manage_camera`.
+
+## UGUI Rules
+
+- Do not solve one screen's edge alignment by pushing full-screen anchor overrides into the variant.
+- If the parent uses a `LayoutGroup`, keep repeated placement parent-owned across base and variants.
+- Variant-local changes should usually stay inside the prefab root: icon treatment, optional badges, text emphasis, decorative frames, minor internal spacing.
+- When a button family or card family exists, prefer one base prefab plus a few clear variants over many unrelated near-duplicates.
+
+## UI Toolkit Equivalent
+
+For UI Toolkit, use the same logic for reusable template families:
+
+- keep one base `UXML` structure
+- apply variant-like differences through scoped classes, optional elements, or wrapper containers
+- avoid copying the base into many almost-identical template files unless inheritance is no longer meaningful
+
+## Common Anti-Patterns
+
+- Creating a variant when direct reuse with different content was enough.
+- Putting one-screen anchor fixes into the variant asset.
+- Overriding so much of the base that the variant is effectively a hidden fork.
+- Editing the base prefab for a local request that should have been solved by a variant.
+- Creating many variants with unclear responsibility instead of a small, readable family.
+
+## Verification Questions
+
+- Is the base prefab still the correct conceptual parent for this variant?
+- Could this have been direct reuse with data changes only?
+- Are the overrides limited and easy to explain?
+- Does the variant keep screen-level placement outside the asset?
+- If the base changes later, will this variant still inherit in a predictable way?

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -170,3 +170,14 @@ Choose explicitly between direct reuse, prefab variant, thin wrapper, or a new b
 Do not edit a shared base prefab for a one-screen request unless you verify the impact on another known usage.
 Keep screen-level placement in the parent container rather than pushing one-screen offsets into the shared prefab.
 ```
+
+## Pattern 16: Use a Prefab Variant, Not a Base Edit
+
+Use when the base prefab is structurally right but the current screen needs scoped differences.
+
+```text
+Inspect the existing base prefab and determine whether this request should be solved as a prefab variant instead of a direct base edit.
+Keep the base contract intact, limit overrides to local visuals, optional sections, or scoped behavior, and do not push one-screen placement rules into the variant asset.
+If the variant would need too many structural overrides, stop and reconsider a wrapper or new base prefab instead.
+Verify the target variant and one related base-family usage with screenshots.
+```


### PR DESCRIPTION
## 변경 내용
- 공용 base에서 안전하게 분기하는 Prefab Variant 전용 가이드 추가
- 기존 프리팹 재사용/프리팹 재사용 가이드와 Variant 규칙 연결
- Variant 전용 MCP 호출 레시피 추가
- Variant 사용 프롬프트 패턴 추가
- 루트 README와 스킬 참조 인덱스 갱신

## 목적
- direct reuse, variant, new base 사이의 경계를 더 명확히 합니다.
- variant에서 override해도 되는 범위와 위험한 override를 분리합니다.
- one-screen 수정이 shared base를 오염시키지 않도록 합니다.

## PR 관계
- 이 PR은 #8 위에 쌓이는 stacked PR입니다.
- #7, #8이 머지되면 base를 main으로 바꿔 후속 머지하면 됩니다.

## 영향 범위
- 문서 전용 변경입니다.
- UGUI 중심 규칙이지만 UI Toolkit의 template-family 대응도 포함합니다.
