### PR TITLE
CHANGELOG 추가 및 v0.2.0 릴리스 준비

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+This project follows a lightweight documentation-focused release flow.
+
+이 프로젝트는 문서 중심 저장소에 맞춘 가벼운 릴리스 흐름을 따릅니다.
+
+## v0.2.0 - 2026-03-27
+
+### Added
+
+- Prefab promotion rules for repeated UI structures
+- Existing prefab reuse rules for choosing reuse, variant, wrapper, or a new base
+- Prefab variant rules for controlled divergence from a shared base
+- MCP call recipes for prefab reuse, existing prefab reuse, and prefab variant workflows
+- Prompt patterns for repeated structures, existing prefab reuse, and prefab variants
+
+### Added / 추가
+
+- 반복 UI 구조를 프리팹으로 승격하는 규칙 추가
+- 기존 프리팹을 직접 재사용할지, Variant/Wrapper로 갈지, 새 Base를 만들지 판단하는 규칙 추가
+- 공용 Base에서 안전하게 분기하는 Prefab Variant 규칙 추가
+- 프리팹 재사용, 기존 프리팹 재사용, Prefab Variant용 MCP 호출 레시피 추가
+- 반복 구조, 기존 프리팹 재사용, Prefab Variant용 프롬프트 패턴 추가
+
+### Changed
+
+- Updated the skill references and root documentation so prefab-oriented workflows are easier to discover
+
+### Changed / 변경
+
+- 프리팹 중심 워크플로를 더 쉽게 찾을 수 있도록 스킬 참조와 루트 문서를 정리
+
+## v0.1.0 - 2026-03-09
+
+### Added
+
+- Initial public release of the `unity-mcp-ui-layout` repository
+- Codex skill package plus platform adapters for Google Antigravity and Claude Artifacts
+- Bilingual root README, MIT license, and the first public GitHub release
+
+### Added / 추가
+
+- `unity-mcp-ui-layout` 저장소 최초 공개 버전
+- Codex 스킬 패키지와 Google Antigravity, Claude Artifacts용 플랫폼 어댑터 추가
+- 루트 README 한영 병기, MIT 라이선스, 첫 GitHub 공개 릴리스 추가

--- a/README.md
+++ b/README.md
@@ -94,7 +94,12 @@ examples/
   popup-safe-area-example.md
 
 CONTRIBUTING.md
+CHANGELOG.md
 ```
+
+## Release Notes / 릴리스 노트
+
+- [`CHANGELOG.md`](./CHANGELOG.md)
 
 ## Platform Notes / 플랫폼 설명
 


### PR DESCRIPTION
## 변경 내용
- CHANGELOG.md 추가
- 루트 README.md에 릴리스 노트 링크 추가
- 0.2.0 릴리스 기준 정리

## 목적
- 공개 저장소의 릴리스 기준을 명확히 합니다.
- 0.1.0 이후 누적된 프리팹 재사용 관련 문서 보강을 한 번의 새 릴리스로 정리합니다.

## 영향 범위
- 문서 전용 변경입니다.
