### PR TITLE
Sprite와 RawImage 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Platform-specific adapters live in:
 - prefab promotion rules for repeated UI structures
 - reuse/variant/new-base decision rules for existing prefabs
 - prefab variant rules for controlled divergence from a shared base
+- sprite/image vs `RawImage` rules for static versus texture-driven UI assets
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -62,6 +63,7 @@ Platform-specific adapters live in:
 - 반복되는 UI 구조를 프리팹으로 승격하는 규칙
 - 기존 프리팹을 재사용/Variant/신규 생성 중 무엇으로 갈지 판단하는 규칙
 - 공용 base에서 안전하게 분기하는 Prefab Variant 규칙
+- 정적 UI 자산에서 sprite/image와 `RawImage`를 어떻게 구분할지에 대한 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -120,6 +120,7 @@ Use screenshots aggressively.
 - Avoid storing a design as "x=742, y=118" unless the UI intentionally targets a fixed render surface with no adaptive behavior.
 - Avoid combining `ContentSizeFitter` and parent layout control in ways that create feedback loops.
 - Do not decompose a likely single-image asset into fake sub-shapes unless interaction, animation, or dynamic layout actually requires separate elements.
+- For static UI visuals, prefer `Image` plus sprite-based assets. Reserve `RawImage` for true texture-driven content such as `RenderTexture`, video, or runtime-generated textures.
 - Treat text as a layout driver. Check wrapping, overflow, best-fit/auto-size, and font asset limits before resizing containers.
 - For UI Toolkit, prefer USS classes and container rules over many inline style overrides.
 - If the user gives only a visual description, assume one target resolution first, implement for that resolution, then test at additional aspect ratios.
@@ -144,6 +145,7 @@ Use screenshots aggressively.
 - Read `references/prefab-variants.md` when one shared base prefab should branch into a controlled family of variants without polluting the base asset.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.
 - Read `references/review-checks.md` when you need a final quality pass before calling a Unity UI task complete.
+- Read `references/sprite-vs-rawimage.md` when static UI assets are being wired through `RawImage` instead of the normal sprite workflow.
 - Read `references/ugui-anchors-canvas-scaler.md` when the target is UGUI or when anchor, pivot, or screen-scaling behavior is causing drift.
 - Read `references/ugui-hud.md` for always-on-screen HUD, minimap, status bars, and action bars.
 - Read `references/ugui-inventory.md` for slot grids, item lists, equipment panels, and shop layouts.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -12,6 +12,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `existing-prefab-reuse.md`
 - `prefab-variants.md`
 - `prefab-reuse.md`
+- `sprite-vs-rawimage.md`
 - `common-failures.md`
 - `review-checks.md`
 

--- a/unity-mcp-ui-layout/references/common-failures.md
+++ b/unity-mcp-ui-layout/references/common-failures.md
@@ -187,7 +187,27 @@ This document is organized by symptom first, because that is usually how problem
 - name the exact region that may change
 - verify the current state before making new structure decisions
 
-## 10. Quick Recovery Strategy
+## 10. Static UI Assets Drift Into RawImage
+
+### Typical symptoms
+
+- static icons, panels, or button visuals are wired through `RawImage`
+- sprite slicing or normal UI asset reuse no longer fits the implementation
+- prefab reuse feels awkward because the visual source is treated like arbitrary texture data
+
+### Likely causes
+
+- `RawImage` was used as a shortcut instead of importing or reusing a proper sprite
+- the agent did not distinguish between a mockup image and a runtime texture source
+- the real issue was asset lookup or import setup, not component type
+
+### Fix direction
+
+- convert ordinary static UI visuals back to `Image` plus sprite-based assets
+- reserve `RawImage` for `RenderTexture`, video, runtime-generated textures, or other true texture-driven cases
+- if the screen already uses sprite-backed UI assets elsewhere, stay consistent with that workflow
+
+## 11. Quick Recovery Strategy
 
 When the work starts drifting, reset the process:
 

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -57,7 +57,17 @@ Ask:
 
 If the UI was decomposed more than the runtime behavior needs, simplify it before shipping.
 
-## 6. Text Check
+## 6. Asset Type Check
+
+Ask:
+
+- Are ordinary static UI visuals using `Image` and sprite-backed assets instead of `RawImage`?
+- If a `RawImage` exists, is there a clear runtime texture source such as `RenderTexture`, video, or generated texture data?
+- Did any static icon, panel, slot, or button art bypass the sprite workflow without a good reason?
+
+If the answer is no, convert the asset usage back toward the normal sprite workflow before calling the UI done.
+
+## 7. Text Check
 
 Ask:
 
@@ -67,7 +77,7 @@ Ask:
 
 Text problems should be treated as layout problems first, not only font-size problems.
 
-## 7. Interaction Area Check
+## 8. Interaction Area Check
 
 Ask:
 
@@ -77,7 +87,7 @@ Ask:
 
 This check is especially important for popup and mobile layouts.
 
-## 8. Safe Area Check
+## 9. Safe Area Check
 
 Ask:
 
@@ -87,7 +97,7 @@ Ask:
 
 If safe area works only because several children have manual offsets, the design still needs cleanup.
 
-## 9. Visual Consistency Check
+## 10. Visual Consistency Check
 
 Ask:
 
@@ -97,7 +107,7 @@ Ask:
 
 This is where hand-placed designs usually reveal themselves.
 
-## 10. Scope Check
+## 11. Scope Check
 
 Ask:
 
@@ -107,7 +117,7 @@ Ask:
 
 If the answer is no, narrow the change before shipping it.
 
-## 11. Final Go/No-Go Rule
+## 12. Final Go/No-Go Rule
 
 Do not call the UI complete unless:
 

--- a/unity-mcp-ui-layout/references/sprite-vs-rawimage.md
+++ b/unity-mcp-ui-layout/references/sprite-vs-rawimage.md
@@ -1,0 +1,88 @@
+# Sprite vs RawImage Rules
+
+Use this guide when Unity UI asset usage starts drifting toward `RawImage` for ordinary static UI visuals that should really stay in the normal sprite workflow.
+
+## Goal
+
+Keep static UI assets in the sprite-based workflow by default, and reserve `RawImage` for true texture-driven cases such as `RenderTexture`, video, runtime-generated textures, or external texture streams.
+
+## Default Rule
+
+- Use `Image` with a `Sprite` for ordinary static UI visuals.
+- Use `RawImage` only when the content is truly texture-driven and not naturally part of the sprite workflow.
+
+## Prefer `Image` + `Sprite` When
+
+- The asset is a normal UI icon, frame, badge, slot background, panel, button background, or decorative sprite.
+- The element should participate in standard UI authoring and asset reuse.
+- You need sprite slicing, packed sprite usage, atlas-driven organization, or normal prefab reuse.
+- The visual is a stable imported UI asset rather than a live texture feed.
+- The region is likely one baked UI image and not a runtime texture source.
+
+## Prefer `RawImage` When
+
+- The source is a `RenderTexture`.
+- The UI displays a camera preview or 3D scene capture.
+- The source is video or another live texture stream.
+- The texture is generated or updated at runtime.
+- The source is not naturally available as a sprite asset and should remain texture-backed.
+
+## Do Not Use `RawImage` Just Because
+
+- it is quicker than importing a proper sprite
+- the asset "looks like an image"
+- the prompt mentioned a screenshot or mockup
+- the element is decorative but static
+- the same visual would normally be used in multiple prefabs or screens
+
+## Why This Matters
+
+If static UI visuals drift into `RawImage`, the workflow usually gets worse:
+
+- sprite slicing and normal UI scaling patterns are bypassed
+- asset reuse becomes weaker
+- prefab families become harder to keep consistent
+- image assets stop matching the expected import pipeline
+- the agent starts treating stable UI art like arbitrary texture data
+
+## Asset-Aware Mode Rule
+
+In asset-aware mode:
+
+- prefer retrieving existing sprite-backed UI assets first
+- preserve sprite-based reuse when the project already uses it
+- do not convert known sprite workflow assets into `RawImage` unless the runtime source truly changed
+
+If a screen already uses a consistent sprite workflow, treat a sudden `RawImage` choice as suspicious and re-check the source type.
+
+## UGUI Rules
+
+- `Image` is the normal default for static UGUI visuals.
+- Use `Sprite` assets for icons, borders, slots, frames, and panel art.
+- If a resizable panel needs 9-slice behavior, it should almost certainly stay in `Image`, not `RawImage`.
+- Do not solve layout problems by swapping `Image` to `RawImage`.
+- If an asset should be atlas-friendly or prefab-friendly, keep it in the sprite pipeline.
+
+## UI Toolkit Equivalent
+
+UI Toolkit does not map one-to-one to `Image` and `RawImage`, but the same principle applies:
+
+- keep stable UI visuals in the normal project asset pipeline
+- avoid treating ordinary static UI art like arbitrary texture data
+- reserve texture-driven display patterns for genuinely dynamic sources
+
+## Common Anti-Patterns
+
+- Static icon shown through `RawImage` even though it should be a sprite.
+- Button background built with `RawImage` so the normal sprite workflow is lost.
+- Panel frame switched to `RawImage` even though 9-slice or normal sprite scaling is needed.
+- Multiple prefabs each wiring the same static texture through `RawImage` instead of sharing sprite assets.
+- Using `RawImage` as a shortcut when the real problem was import setup or asset lookup.
+
+## Verification Questions
+
+- Is this a true texture-driven element, or just a static UI image?
+- Would the project be more consistent if this stayed in the sprite workflow?
+- Does this element need sprite slicing, atlas reuse, or normal prefab-friendly UI art behavior?
+- If this is a `RawImage`, can you clearly explain the runtime texture source?
+- If the answer is no, should this be converted back to `Image` + `Sprite`?


### PR DESCRIPTION
## 변경 내용
- 정적 UI 자산에서 Image + Sprite를 기본값으로 두는 전용 가이드 추가
- RawImage는 RenderTexture, 비디오, 런타임 생성 텍스처 같은 texture-driven 케이스에만 쓰도록 규칙화
- 스킬 본문, 실패 패턴, 최종 검수 체크, 루트 README에 관련 규칙 반영

## 목적
- 자산 활용 단계에서 정적 UI 이미지까지 RawImage로 처리되는 경향을 줄입니다.
- 스프라이트 기반 UI 워크플로와 prefab 재사용 흐름을 더 일관되게 유지합니다.
- RawImage 사용이 정말 필요한 경우와 아닌 경우를 분명하게 구분합니다.

## 영향 범위
- 문서 전용 변경입니다.
