### PR TITLE
시안 분해 기준과 예시 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Platform-specific adapters live in:
 - prefab variant rules for controlled divergence from a shared base
 - sprite/image vs `RawImage` rules for static versus texture-driven UI assets
 - mockup-native resolution rules when a design image exists
+- mockup decomposition rules for deciding what should stay baked, what should split, and what should become reusable blocks
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -66,6 +67,7 @@ Platform-specific adapters live in:
 - 공용 base에서 안전하게 분기하는 Prefab Variant 규칙
 - 정적 UI 자산에서 sprite/image와 `RawImage`를 어떻게 구분할지에 대한 규칙
 - 시안 이미지가 있을 때 시안의 원본 해상도를 기준 프레임으로 삼는 규칙
+- 시안 요소를 어디까지 분해하고 어디를 단일 자산이나 재사용 블록으로 유지할지에 대한 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ Use these files when you want a copyable starting point instead of only referenc
 
 - `hud-example.md`
 - `inventory-example.md`
+- `mockup-resolution-example.md`
 - `popup-safe-area-example.md`
 
 ## How to Use
@@ -28,4 +29,5 @@ Use these files when you want a copyable starting point instead of only referenc
 
 1. `hud-example.md` if you are starting with a composition-driven overlay
 2. `inventory-example.md` if your UI is slot- or list-based
-3. `popup-safe-area-example.md` if mobile safe area and modal structure matter
+3. `mockup-resolution-example.md` if the mockup's native pixel resolution should drive planning
+4. `popup-safe-area-example.md` if mobile safe area and modal structure matter

--- a/examples/mockup-resolution-example.md
+++ b/examples/mockup-resolution-example.md
@@ -1,0 +1,36 @@
+# Mockup Resolution Example
+
+This example shows how to work from a design image when the mockup's own pixel resolution matters.
+
+## Scenario
+
+- A mockup image exists
+- The mockup export is `1600x900`
+- The final implementation target is `1920x1080`
+- The screen is a UGUI HUD with repeated status widgets
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to build this UGUI HUD from the attached mockup.
+The mockup image is 1600x900 and the implementation target is 1920x1080.
+Use the mockup resolution as the composition measurement space and 1920x1080 as the implementation and verification space.
+Group the top-level composition into anchor-owned regions first.
+Do not decompose decorative baked regions unless runtime behavior requires it.
+Turn repeated status widgets into one reusable prefab or reusable layout block.
+Verify the result with screenshots at 1920x1080 and one alternate aspect ratio.
+```
+
+## Why This Example Matters
+
+- It avoids silently treating every design as if it were authored for `1920x1080`.
+- It separates composition measurement from implementation resolution.
+- It reinforces that repeated UI should be reusable.
+- It reinforces that decorative baked art should not be over-decomposed.
+
+## What To Watch For
+
+- Do not copy raw `1600x900` pixel positions directly into the final layout.
+- Normalize positions and sizes against `1600x900` first.
+- Then map those ratios into anchors, offsets, and sizing rules for `1920x1080`.
+- If the same widget repeats, do not rebuild it by hand.

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -144,6 +144,7 @@ Use screenshots aggressively.
 - Read `references/common-failures.md` when the UI result technically exists but still feels fragile, inconsistent, overfit to one resolution, or structurally wrong.
 - Read `references/image-to-layout.md` when the user provides a mockup, screenshot, wireframe, or other layout image plus a target resolution.
 - Read `references/mcp-call-recipes.md` when you need concrete `unity-mcp` call sequences for discovery, creation, repair, verification, or script-backed UI work.
+- Read `references/mockup-decomposition.md` when a design image exists and you need to decide which regions should stay as one asset, which should be split, and which should become reusable blocks.
 - Read `references/mockup-resolution.md` when a design image exists and its own native resolution should become the planning reference frame.
 - Read `references/existing-prefab-reuse.md` when the project likely already contains a similar reusable UI block and you need to choose reuse, variant, wrapper, or a new base prefab.
 - Read `references/prefab-variants.md` when one shared base prefab should branch into a controlled family of variants without polluting the base asset.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -9,6 +9,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `layout-checklist.md`
 - `image-to-layout.md` - includes the asset-RAG fallback contract for when `unity-resource-rag` is unavailable or low-confidence.
 - `mcp-call-recipes.md`
+- `mockup-decomposition.md`
 - `mockup-resolution.md`
 - `existing-prefab-reuse.md`
 - `prefab-variants.md`

--- a/unity-mcp-ui-layout/references/image-to-layout.md
+++ b/unity-mcp-ui-layout/references/image-to-layout.md
@@ -3,6 +3,7 @@
 Use this guide when the user provides a layout image, mockup, wireframe, or screenshot together with a target resolution.
 
 Pair it with `mockup-resolution.md` when the mockup's own native pixel size should become the planning reference frame.
+Pair it with `mockup-decomposition.md` when you need a stricter rule for deciding what should stay as one asset versus what should become runtime-owned UI.
 
 ## Goal
 
@@ -59,6 +60,7 @@ Break the layout into:
 
 Do not jump directly from whole image to dozens of leaf nodes.
 Group the topmost composition by anchor-owned regions first so the largest blocks already belong to stable screen relationships.
+Split only when runtime behavior requires it, and keep likely decorative baked regions whole.
 
 ### 2. Estimate normalized geometry
 

--- a/unity-mcp-ui-layout/references/mockup-decomposition.md
+++ b/unity-mcp-ui-layout/references/mockup-decomposition.md
@@ -1,0 +1,86 @@
+# Mockup Decomposition Rules
+
+Use this guide when a mockup or design image exists and you need to decide which regions should stay as one asset, which should become reusable layout blocks, and which should be separated into interactive UI elements.
+
+## Goal
+
+Decompose the mockup only as far as runtime behavior needs. Keep the hierarchy honest, avoid fake widget explosion, and preserve reusable structure where the design clearly repeats.
+
+## Core Rule
+
+Decompose by runtime responsibility, not by visual outline alone.
+
+- keep decorative or baked regions whole when they do not need separate behavior
+- split elements that need interaction, dynamic text, animation, state changes, or adaptive layout
+- promote repeated structures into reusable blocks or prefabs instead of rebuilding them by hand
+
+## Decomposition Flow
+
+```mermaid
+flowchart TD
+    A["Mockup region identified"] --> B{"Needs interaction, data, animation, or adaptive layout?"}
+    B -- "No" --> C{"Appears visually baked into one asset?"}
+    C -- "Yes" --> D["Keep as one image/sprite region"]
+    C -- "No" --> E{"Repeats as the same structure?"}
+    E -- "Yes" --> F["Extract as reusable layout block or prefab"]
+    E -- "No" --> G["Keep as one simple visual block"]
+    B -- "Yes" --> H["Split into runtime-owned UI elements"]
+    H --> I{"Same structure repeats?"}
+    I -- "Yes" --> F
+    I -- "No" --> J["Keep as unique interactive block"]
+```
+
+## Keep As One Region When
+
+- The area is mostly decorative.
+- The design looks like one baked panel, illustration, or ornament.
+- No sub-part needs its own click, hover, state, text swap, or animation.
+- Splitting it would only create fake child objects that mirror visual shapes but not runtime meaning.
+
+## Split Into UI Elements When
+
+- A sub-part is clickable or selectable.
+- A label, number, icon, or badge changes at runtime.
+- A region needs to resize or reflow with resolution or content.
+- A child needs a separate state such as selected, locked, disabled, highlighted, or empty.
+- Safe area, localization, or adaptive layout requires independent control.
+
+## Promote To Reusable Blocks When
+
+- The same card, slot, row, badge cluster, or button group repeats.
+- The same shape appears across screens with mostly data-level differences.
+- The repeated structure would be fragile if rebuilt manually each time.
+
+## Decomposition Priorities
+
+Prefer this order:
+
+1. screen-level anchor-owned regions
+2. reusable repeated blocks
+3. unique interactive elements
+4. decorative single-image regions
+
+Do not start by tracing every visible edge in the mockup into a separate node.
+
+## Warning Signs Of Over-Decomposition
+
+- Many empty `Image` objects exist only to mimic visual seams.
+- Decorative borders or background ornaments are split into many children without runtime purpose.
+- A single card frame becomes a deep tree of static fragments.
+- The hierarchy grows faster than the actual interactive responsibilities.
+- The screen only "matches the mockup" because many raw offsets compensate for fake visual layers.
+
+## Warning Signs Of Under-Decomposition
+
+- A button is baked into a background image but needs interaction.
+- Dynamic text is trapped inside a decorative combined asset.
+- A repeated list item is still being rebuilt from loose children each time.
+- A region that should adapt to content stays locked as a flat image.
+
+## Review Questions
+
+- Which regions are decorative only, and should remain whole?
+- Which regions need runtime ownership and must be split?
+- Which repeated structures should become reusable prefabs or layout blocks?
+- Did we decompose based on behavior and layout needs, not just visual outlines?
+- Would another engineer understand why each region exists at runtime?

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -96,6 +96,17 @@ Estimate geometry as normalized ratios from the mockup, then convert those ratio
 If a separate target resolution is later provided, keep the mockup as the composition space and the target resolution as the implementation space.
 ```
 
+## Pattern 18: Decompose the Mockup by Runtime Responsibility
+
+Use when a mockup exists and the agent might over-split decorative regions into fake widgets.
+
+```text
+Before creating objects, inspect the mockup and decide which regions should stay as one baked visual asset, which regions should become interactive UI elements, and which repeated regions should become reusable blocks.
+Decompose by runtime responsibility, not by visual outline alone.
+Keep decorative regions whole unless interaction, animation, dynamic text, or adaptive layout requires separation.
+Turn repeated structures into reusable prefabs or reusable layout blocks instead of rebuilding them manually.
+```
+
 ## Pattern 8: Script-Aware UI Editing
 
 Use when script changes are necessary.

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -55,6 +55,7 @@ Ask:
 - Did we keep likely single-image regions as single image resources?
 - Was any decorative area split into fake widgets without a runtime need?
 - Do separate elements exist only where interaction, animation, text, or adaptive layout requires them?
+- Were repeated mockup regions promoted into reusable blocks where appropriate instead of being manually rebuilt?
 
 If the UI was decomposed more than the runtime behavior needs, simplify it before shipping.
 


### PR DESCRIPTION
## 변경 내용
- 시안을 런타임 책임 기준으로 분해하는 전용 가이드 추가
- 장식/베이크 영역 유지, 상호작용 요소 분리, 반복 구조의 재사용 승격 기준 추가
- 시안 해상도 규칙이 적용된 예시 문서 추가
- 관련 규칙을 SKILL, image-to-layout, prompt patterns, review checks, examples index, root README에 반영

## 목적
- 시안을 시각 윤곽만 보고 과하게 쪼개는 문제를 줄입니다.
- 어떤 영역을 단일 자산으로 유지하고 어떤 영역을 런타임 UI로 분리해야 하는지 명확히 합니다.
- mockup 해상도 규칙이 실제 프롬프트에서 어떻게 쓰이는지 예시로 보강합니다.

## PR 관계
- 이 PR은 #14 위에 쌓이는 stacked PR입니다.
- #14가 머지되면 base를 main으로 바꾸거나 후속으로 머지하면 됩니다.

## 영향 범위
- 문서 전용 변경입니다.
