### PR TITLE
UI 변경 모드 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Platform-specific adapters live in:
 - sprite/image vs `RawImage` rules for static versus texture-driven UI assets
 - mockup-native resolution rules when a design image exists
 - mockup decomposition rules for deciding what should stay baked, what should split, and what should become reusable blocks
+- repair mode vs greenfield build mode rules for existing-screen fixes versus new UI creation
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -68,6 +69,7 @@ Platform-specific adapters live in:
 - 정적 UI 자산에서 sprite/image와 `RawImage`를 어떻게 구분할지에 대한 규칙
 - 시안 이미지가 있을 때 시안의 원본 해상도를 기준 프레임으로 삼는 규칙
 - 시안 요소를 어디까지 분해하고 어디를 단일 자산이나 재사용 블록으로 유지할지에 대한 규칙
+- 기존 UI 수정 요청과 신규 UI 생성 요청을 구분하는 작업 모드 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -34,6 +34,8 @@ Read the current context before making changes.
 - If the user provides a layout image and target resolution, treat them as the source spec for composition before creating any objects.
 - If the user provides a layout image but no explicit target resolution, capture the image's native resolution and treat that as the initial reference frame.
 
+Before planning changes, decide whether the task should stay in bounded repair mode or operate in greenfield build mode. Do not silently treat an existing-screen repair request like a full rebuild.
+
 After the initial scene/editor inspection, run a quick capability check before planning the implementation:
 
 - Detect whether `unity-resource-rag` MCP/tools are available.
@@ -146,6 +148,7 @@ Use screenshots aggressively.
 - Read `references/mcp-call-recipes.md` when you need concrete `unity-mcp` call sequences for discovery, creation, repair, verification, or script-backed UI work.
 - Read `references/mockup-decomposition.md` when a design image exists and you need to decide which regions should stay as one asset, which should be split, and which should become reusable blocks.
 - Read `references/mockup-resolution.md` when a design image exists and its own native resolution should become the planning reference frame.
+- Read `references/ui-change-modes.md` when you need to decide whether the task should be handled as bounded repair or as a new build.
 - Read `references/existing-prefab-reuse.md` when the project likely already contains a similar reusable UI block and you need to choose reuse, variant, wrapper, or a new base prefab.
 - Read `references/prefab-variants.md` when one shared base prefab should branch into a controlled family of variants without polluting the base asset.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -11,6 +11,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `mcp-call-recipes.md`
 - `mockup-decomposition.md`
 - `mockup-resolution.md`
+- `ui-change-modes.md`
 - `existing-prefab-reuse.md`
 - `prefab-variants.md`
 - `prefab-reuse.md`

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -44,6 +44,16 @@ Inspect the parent chain first and explain whether the issue comes from scaling,
 Apply the smallest structural fix, then verify with a screenshot.
 ```
 
+## Pattern 4A: Stay In Repair Mode
+
+Use when the screen already exists and the user wants a bounded fix, not a redesign.
+
+```text
+Treat this as a repair of the existing UI, not as a new screen build.
+Inspect the current parent chain first, keep the scope bounded to the named region, and preserve the current style unless it is the direct source of the problem.
+Only widen the change if you can explain why the parent structure or shared asset is the real cause.
+```
+
 ## Pattern 5: Cross-Resolution Verification
 
 Use before finalizing.
@@ -125,6 +135,16 @@ Use when the request is vague.
 Do not generate the whole UI at once.
 Inspect first, then create or fix the interface in small slices.
 Prioritize structure over visual polish, and verify each slice with a screenshot before moving on.
+```
+
+## Pattern 9A: Decide Repair Mode vs Build Mode First
+
+Use when it is not yet clear whether the request is a bounded repair or a fresh screen build.
+
+```text
+Inspect the current UI first and decide whether this request should stay in repair mode or switch to build mode.
+If the relevant UI already exists, default to repair mode until a rebuild is clearly justified.
+If a rebuild is required, explain why the existing structure is not worth preserving before switching modes.
 ```
 
 ## Pattern 10: UGUI HUD Build

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -116,6 +116,7 @@ Ask:
 - Did the task stay inside the requested region?
 - Were unrelated screens or widgets changed unnecessarily?
 - Was the original style preserved when the request was a repair?
+- Did we stay in the correct operating mode: bounded repair for fixes, or build mode for true greenfield work?
 
 If the answer is no, narrow the change before shipping it.
 

--- a/unity-mcp-ui-layout/references/ui-change-modes.md
+++ b/unity-mcp-ui-layout/references/ui-change-modes.md
@@ -1,0 +1,92 @@
+# UI Change Modes
+
+Use this guide when a Unity UI request could be interpreted either as repairing existing UI or building a new UI from scratch.
+
+## Goal
+
+Choose the correct operating mode early so the agent does not redesign an existing screen when the task was a bounded repair, and does not over-preserve broken structure when the task was really a greenfield build.
+
+## Two Modes
+
+### 1. Repair Mode
+
+Use this when the UI already exists and the user wants it fixed, aligned, stabilized, or brought closer to a reference.
+
+Typical signals:
+
+- "fix"
+- "repair"
+- "adjust"
+- "align"
+- "match this image"
+- "keep the current style"
+- "do not rebuild everything"
+
+### 2. Build Mode
+
+Use this when the screen does not exist yet or when the user clearly wants a fresh implementation.
+
+Typical signals:
+
+- "build"
+- "create"
+- "make this screen"
+- "new HUD"
+- "new popup"
+- "from scratch"
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A["UI request received"] --> B{"Relevant UI already exists?"}
+    B -- "No" --> C["Build Mode"]
+    B -- "Yes" --> D{"User asks to preserve current style/structure or only fix a region?"}
+    D -- "Yes" --> E["Repair Mode"]
+    D -- "No" --> F{"Current UI is unusable and user wants replacement?"}
+    F -- "Yes" --> C
+    F -- "No" --> E
+```
+
+## Repair Mode Rules
+
+- Inspect the current UI before proposing structure changes.
+- Keep scope bounded to the named region unless the parent chain forces a wider structural fix.
+- Preserve existing style, prefab choices, and asset workflow unless they are the actual source of the problem.
+- Prefer the smallest structural change that solves the issue.
+- Explain when a wider change is required because the real problem lives in the parent container or shared prefab.
+
+## Build Mode Rules
+
+- Start from the root shell and main regions first.
+- Treat the request as greenfield unless the user explicitly asks to inherit from existing UI.
+- Create structure before visual polish.
+- Use reusable blocks and prefab rules early if repetition is obvious.
+
+## Mixed Cases
+
+Some requests look like repair but actually need rebuild-level scope. In that case:
+
+- still start in Repair Mode
+- inspect the current screen first
+- explicitly state why bounded repair is not enough
+- then switch to Build Mode for the affected region only if needed
+
+Do not silently jump from repair into redesign.
+
+## Common Failure Pattern
+
+The most common mistake is this:
+
+- the user asks for a fix
+- the agent treats the task like a new screen build
+- unrelated layout and style drift are introduced
+
+If that risk exists, default to Repair Mode until the need for a rebuild is proven.
+
+## Verification Questions
+
+- Did we identify whether this was a repair or a new build before editing?
+- If this was a repair, did we keep scope bounded?
+- If this was a build, did we avoid over-preserving broken old structure?
+- If the mode changed mid-task, was that change explained clearly?


### PR DESCRIPTION
## 변경 내용
- 기존 UI 수정 요청과 신규 UI 생성 요청을 구분하는 전용 가이드 추가
- Repair Mode와 Build Mode의 판단 기준 및 전환 규칙 추가
- 관련 규칙을 SKILL, prompt patterns, review checks, README에 반영

## 목적
- '고쳐달라' 요청을 새 화면 생성처럼 처리하는 문제를 줄입니다.
- bounded repair와 greenfield build를 더 명확하게 나눕니다.
- 기존 UI를 존중해야 하는 작업과 새로 구성해야 하는 작업의 흐름을 구분합니다.

## 영향 범위
- 문서 전용 변경입니다.
