### PR TITLE
자산 탐색 우선순위 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Platform-specific adapters live in:
 - mockup-native resolution rules when a design image exists
 - mockup decomposition rules for deciding what should stay baked, what should split, and what should become reusable blocks
 - repair mode vs greenfield build mode rules for existing-screen fixes versus new UI creation
+- asset discovery priority rules for prefab, sprite, font, material, and placeholder reuse order
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -70,6 +71,7 @@ Platform-specific adapters live in:
 - 시안 이미지가 있을 때 시안의 원본 해상도를 기준 프레임으로 삼는 규칙
 - 시안 요소를 어디까지 분해하고 어디를 단일 자산이나 재사용 블록으로 유지할지에 대한 규칙
 - 기존 UI 수정 요청과 신규 UI 생성 요청을 구분하는 작업 모드 규칙
+- 프리팹, 스프라이트, 폰트, 머티리얼, 플레이스홀더를 어떤 순서로 찾을지에 대한 자산 탐색 우선순위 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -48,6 +48,7 @@ After the initial scene/editor inspection, run a quick capability check before p
   - the project already contains similar UI and consistency clearly matters
 - If those reuse signals are absent, stay in layout-only mode even if asset-retrieval tooling is available.
 - If asset-aware mode is warranted and both `unity-resource-rag` and an asset catalog or asset index are available, look for matching reusable assets before building replacements from scratch.
+- In asset-aware mode, follow a stable discovery order: reusable prefabs first, then variants or wrappers, then sprite-backed visuals, then text styles, then materials, and placeholders last.
 - If asset-aware mode is warranted but `unity-resource-rag` is unavailable, continue with image-to-layout translation using the existing layout rules, preserve structure-first execution, use placeholder visuals or existing manually discovered assets, and explicitly state that asset-aware retrieval was skipped.
 - If asset-aware mode is warranted and `unity-resource-rag` is available but retrieval confidence is low, do not force an asset match, keep the layout workflow moving, mark visuals as provisional, and verify structure first.
 - Missing or low-confidence asset-RAG capability is not a hard blocker unless the user explicitly requires asset-index-backed reuse.
@@ -149,6 +150,7 @@ Use screenshots aggressively.
 - Read `references/mockup-decomposition.md` when a design image exists and you need to decide which regions should stay as one asset, which should be split, and which should become reusable blocks.
 - Read `references/mockup-resolution.md` when a design image exists and its own native resolution should become the planning reference frame.
 - Read `references/ui-change-modes.md` when you need to decide whether the task should be handled as bounded repair or as a new build.
+- Read `references/asset-discovery-priority.md` when asset-aware mode is active and you need to decide what kinds of existing assets to search in what order.
 - Read `references/existing-prefab-reuse.md` when the project likely already contains a similar reusable UI block and you need to choose reuse, variant, wrapper, or a new base prefab.
 - Read `references/prefab-variants.md` when one shared base prefab should branch into a controlled family of variants without polluting the base asset.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -12,6 +12,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `mockup-decomposition.md`
 - `mockup-resolution.md`
 - `ui-change-modes.md`
+- `asset-discovery-priority.md`
 - `existing-prefab-reuse.md`
 - `prefab-variants.md`
 - `prefab-reuse.md`

--- a/unity-mcp-ui-layout/references/asset-discovery-priority.md
+++ b/unity-mcp-ui-layout/references/asset-discovery-priority.md
@@ -1,0 +1,62 @@
+# Asset Discovery Priority
+
+Use this guide when asset-aware mode is active and you need a stable order for checking what the project already has before introducing placeholders or new assets.
+
+## Goal
+
+Prevent random asset choices by following a clear discovery order for existing reusable UI assets.
+
+## Default Discovery Order
+
+Prefer this order:
+
+1. existing reusable prefab or reusable block
+2. prefab variant or wrapper candidate
+3. existing sprite, atlas entry, or sprite-backed UI image
+4. existing font, TMP style, or text style system
+5. existing material or shared visual treatment
+6. placeholder asset or provisional visual
+
+Do not skip straight to placeholders if higher-confidence reusable assets already exist.
+
+## Why This Order
+
+- Prefabs preserve structure and behavior, not just appearance.
+- Variants and wrappers preserve family consistency.
+- Sprites preserve the normal UI art workflow.
+- Fonts and text styles preserve readability and hierarchy.
+- Materials are usually finishing details, not the first reuse anchor.
+- Placeholders are acceptable when discovery fails, but should be the last normal step, not the first.
+
+## Practical Rules
+
+- If the same widget already exists as a prefab, check that first before reassembling it from sprites.
+- If the same family exists but the current screen needs scoped differences, check for variant or wrapper paths next.
+- If no prefab fit exists, look for existing sprite-backed visuals before inventing new temporary art.
+- Keep font and text-style reuse deliberate so the screen does not drift away from the project's UI voice.
+- Use placeholders only when real asset retrieval is unavailable, low-confidence, or genuinely absent.
+
+## Asset-Aware Mode Behavior
+
+In asset-aware mode:
+
+- inspect reusable prefab candidates first
+- then inspect sprite-backed art and text systems
+- only after that fall back to placeholder visuals
+
+If the project already has a stable widget family, treat a sudden placeholder-driven rebuild as suspicious.
+
+## Common Anti-Patterns
+
+- Building a widget from scratch even though a close prefab already exists.
+- Jumping to a placeholder icon before checking the existing sprite or atlas workflow.
+- Reusing a random material first even though the real reuse anchor should have been a prefab or sprite.
+- Letting text styles drift because font/TMP reuse was never checked.
+- Treating low-confidence asset lookup as permission to stop checking obvious nearby reusable assets.
+
+## Verification Questions
+
+- Did we check reusable prefabs before reconstructing UI from lower-level assets?
+- Did we check sprite-backed visuals before inventing placeholders?
+- Did we preserve existing font or text style conventions where relevant?
+- Are placeholders clearly provisional rather than silent permanent replacements?

--- a/unity-mcp-ui-layout/references/common-failures.md
+++ b/unity-mcp-ui-layout/references/common-failures.md
@@ -207,7 +207,28 @@ This document is organized by symptom first, because that is usually how problem
 - reserve `RawImage` for `RenderTexture`, video, runtime-generated textures, or other true texture-driven cases
 - if the screen already uses sprite-backed UI assets elsewhere, stay consistent with that workflow
 
-## 11. Quick Recovery Strategy
+## 11. The Agent Skips Obvious Existing Assets
+
+### Typical symptoms
+
+- a placeholder-heavy UI is built even though similar widgets already exist in the project
+- a repeated widget is reconstructed from loose parts even though a prefab family already exists
+- text and icon styling drift away from the rest of the project
+
+### Likely causes
+
+- asset-aware mode was entered, but no clear lookup order was followed
+- placeholder creation started before prefab or sprite reuse was checked
+- the agent treated low-confidence retrieval as permission to stop checking nearby reusable assets
+
+### Fix direction
+
+- check reusable prefabs first
+- then check variant or wrapper paths
+- then check sprite-backed visuals, text styles, and materials
+- leave placeholders as a deliberate last resort, not a default first step
+
+## 12. Quick Recovery Strategy
 
 When the work starts drifting, reset the process:
 

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -147,6 +147,16 @@ If the relevant UI already exists, default to repair mode until a rebuild is cle
 If a rebuild is required, explain why the existing structure is not worth preserving before switching modes.
 ```
 
+## Pattern 9B: Follow Asset Discovery Priority
+
+Use when asset-aware mode is active and the project likely already has reusable UI assets.
+
+```text
+Treat this as asset-aware work and follow a strict discovery order.
+Check reusable prefabs first, then variant or wrapper paths, then existing sprite-backed visuals, then text style systems, then materials, and use placeholders only if those higher-priority options are unavailable or low-confidence.
+Do not jump straight to placeholder-driven reconstruction while obvious reusable assets still exist.
+```
+
 ## Pattern 10: UGUI HUD Build
 
 Use when building or repairing a HUD.

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -56,6 +56,7 @@ Ask:
 - Was any decorative area split into fake widgets without a runtime need?
 - Do separate elements exist only where interaction, animation, text, or adaptive layout requires them?
 - Were repeated mockup regions promoted into reusable blocks where appropriate instead of being manually rebuilt?
+- If asset-aware mode was active, did we follow a sensible discovery order instead of jumping straight to placeholders?
 
 If the UI was decomposed more than the runtime behavior needs, simplify it before shipping.
 


### PR DESCRIPTION
## 변경 내용
- asset-aware mode에서 사용할 자산 탐색 우선순위 전용 가이드 추가
- prefab → variant/wrapper → sprite/atlas → font/TMP style → material → placeholder 순서 규칙 추가
- 관련 규칙을 SKILL, failures, prompt patterns, review checks, README에 반영

## 목적
- 자산 활용 단계에서 임의의 placeholder나 느슨한 재구성이 먼저 나오는 문제를 줄입니다.
- 기존 prefab, sprite, font, material 재사용 흐름을 더 일관되게 만듭니다.
- asset-aware mode를 실제 사용 가능한 탐색 순서로 정리합니다.

## 영향 범위
- 문서 전용 변경입니다.
