### PR TITLE
자산 네이밍과 폴더 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Platform-specific adapters live in:
 - mockup decomposition rules for deciding what should stay baked, what should split, and what should become reusable blocks
 - repair mode vs greenfield build mode rules for existing-screen fixes versus new UI creation
 - asset discovery priority rules for prefab, sprite, font, material, and placeholder reuse order
+- asset naming and folder rules so reusable assets stay discoverable and screen-owned assets stay scoped correctly
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -72,6 +73,7 @@ Platform-specific adapters live in:
 - 시안 요소를 어디까지 분해하고 어디를 단일 자산이나 재사용 블록으로 유지할지에 대한 규칙
 - 기존 UI 수정 요청과 신규 UI 생성 요청을 구분하는 작업 모드 규칙
 - 프리팹, 스프라이트, 폰트, 머티리얼, 플레이스홀더를 어떤 순서로 찾을지에 대한 자산 탐색 우선순위 규칙
+- 재사용 자산은 다시 찾기 쉽고 화면 전용 자산은 범위가 드러나도록 만드는 자산 네이밍/폴더 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -49,6 +49,7 @@ After the initial scene/editor inspection, run a quick capability check before p
 - If those reuse signals are absent, stay in layout-only mode even if asset-retrieval tooling is available.
 - If asset-aware mode is warranted and both `unity-resource-rag` and an asset catalog or asset index are available, look for matching reusable assets before building replacements from scratch.
 - In asset-aware mode, follow a stable discovery order: reusable prefabs first, then variants or wrappers, then sprite-backed visuals, then text styles, then materials, and placeholders last.
+- In asset-aware mode, name and place any new reusable assets deliberately so future discovery stays predictable: shared assets should read as shared, screen-specific assets should stay near the screen that owns them, and placeholder assets should stay visibly provisional.
 - If asset-aware mode is warranted but `unity-resource-rag` is unavailable, continue with image-to-layout translation using the existing layout rules, preserve structure-first execution, use placeholder visuals or existing manually discovered assets, and explicitly state that asset-aware retrieval was skipped.
 - If asset-aware mode is warranted and `unity-resource-rag` is available but retrieval confidence is low, do not force an asset match, keep the layout workflow moving, mark visuals as provisional, and verify structure first.
 - Missing or low-confidence asset-RAG capability is not a hard blocker unless the user explicitly requires asset-index-backed reuse.
@@ -151,6 +152,7 @@ Use screenshots aggressively.
 - Read `references/mockup-resolution.md` when a design image exists and its own native resolution should become the planning reference frame.
 - Read `references/ui-change-modes.md` when you need to decide whether the task should be handled as bounded repair or as a new build.
 - Read `references/asset-discovery-priority.md` when asset-aware mode is active and you need to decide what kinds of existing assets to search in what order.
+- Read `references/asset-naming-and-folders.md` when asset-aware mode is creating, extracting, or reorganizing UI assets and you need stable naming plus shared-versus-screen folder rules.
 - Read `references/existing-prefab-reuse.md` when the project likely already contains a similar reusable UI block and you need to choose reuse, variant, wrapper, or a new base prefab.
 - Read `references/prefab-variants.md` when one shared base prefab should branch into a controlled family of variants without polluting the base asset.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -13,6 +13,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `mockup-resolution.md`
 - `ui-change-modes.md`
 - `asset-discovery-priority.md`
+- `asset-naming-and-folders.md`
 - `existing-prefab-reuse.md`
 - `prefab-variants.md`
 - `prefab-reuse.md`

--- a/unity-mcp-ui-layout/references/asset-naming-and-folders.md
+++ b/unity-mcp-ui-layout/references/asset-naming-and-folders.md
@@ -1,0 +1,173 @@
+# Asset Naming and Folder Rules
+
+Use this guide when asset-aware mode creates, promotes, or reorganizes UI assets.
+
+The goal is simple: if an agent creates or extracts a useful asset today, another agent should be able to find and reuse it later without guessing.
+
+## 1. Core Naming Principles
+
+- Prefer short names that reveal role immediately.
+- Encode UI purpose and scope, not editor history.
+- Keep shared assets clearly separate from screen-specific assets.
+- Name assets by meaning, not by pixel position or target resolution.
+- If an asset is only provisional, mark it clearly as placeholder work.
+
+Good names help discovery, reuse, and safe prefab promotion.
+
+Bad names create accidental duplication.
+
+Avoid names like:
+
+- `Button_New`
+- `Panel_Final2`
+- `InventorySlot_Copy`
+- `TopLeft_1920_Button`
+- `Popup_v3_really_final`
+
+## 2. Scope First: Shared vs Screen-Specific
+
+Before naming or placing a new asset, decide its scope.
+
+- Put the asset in a shared folder only if the structure, styling intent, and likely reuse all point toward cross-screen reuse.
+- Keep the asset in a screen-specific folder when it mainly serves one screen, one feature flow, or one temporary production stage.
+- If scope is unclear, prefer screen-specific placement first. Promote to shared only after reuse is visible.
+
+## 3. Recommended Folder Shape
+
+Use a predictable folder layout so retrieval can stay stable.
+
+```mermaid
+flowchart TD
+    A["Assets/UI"] --> B["Common"]
+    A --> C["Screens/<ScreenName>"]
+    B --> B1["Prefabs"]
+    B --> B2["Sprites"]
+    B --> B3["Materials"]
+    B --> B4["Fonts or TMP"]
+    C --> C1["Prefabs"]
+    C --> C2["Sprites"]
+    C --> C3["Materials"]
+    C --> C4["Placeholders"]
+```
+
+Recommended examples:
+
+- `Assets/UI/Common/Prefabs`
+- `Assets/UI/Common/Sprites`
+- `Assets/UI/Common/Materials`
+- `Assets/UI/Common/TMP`
+- `Assets/UI/Screens/HUD/Prefabs`
+- `Assets/UI/Screens/Inventory/Prefabs`
+- `Assets/UI/Screens/Popup/Placeholders`
+
+The exact project folder shape can vary, but the intent should stay clear:
+
+- shared things live in shared locations
+- screen-owned things live near that screen
+- placeholder work stays visibly provisional
+
+## 4. Recommended Naming Patterns
+
+Choose one stable family pattern and keep it consistent.
+
+### Prefabs
+
+- Shared base prefab: `UI_Common_Button_Primary`
+- Shared reusable row: `UI_Common_StatusRow`
+- Screen-specific prefab: `UI_Inventory_Slot`
+- Screen-specific popup root: `UI_Settings_PopupRoot`
+
+### Prefab Variants
+
+- `UI_Common_Button_Primary_Selected`
+- `UI_Common_Button_Primary_Disabled`
+- `UI_Reward_Card_Epic`
+
+Keep the base family name intact and append only the scoped difference.
+
+### Sprites
+
+- `UI_Common_Icon_Gold`
+- `UI_Inventory_Frame_Rare`
+- `UI_HUD_BarFill_HP`
+
+### Materials
+
+- `UI_Common_Grayscale`
+- `UI_Popup_BlurOverlay`
+
+### TMP Styles or Font Assets
+
+- `TMP_Common_Title_L`
+- `TMP_Common_Body_M`
+- `TMP_HUD_Number_L`
+
+## 5. Naming Rules for Reuse Promotion
+
+When a repeated structure is promoted into a reusable prefab:
+
+- Name the prefab by role, not by current scene position.
+- Keep screen ownership out of the name if the asset is truly cross-screen.
+- Keep screen ownership in the name if reuse is still local to one screen family.
+- Avoid baking state names into the base asset if the state should be a variant instead.
+
+Use:
+
+- `UI_Common_ItemCard`
+- `UI_Inventory_ItemCard`
+
+Avoid:
+
+- `UI_LeftPanelCard`
+- `InventoryCard_01`
+- `RareCardBaseMaybe`
+
+## 6. Folder Rules for Variants and Wrappers
+
+When using variants or wrappers:
+
+- Keep variants near the base prefab family so reuse remains discoverable.
+- Use a `Variants` subfolder only if the family is large enough to justify it.
+- Keep thin wrappers close to the screen that owns the wrapper behavior.
+
+Examples:
+
+- `Assets/UI/Common/Prefabs/Buttons/UI_Common_Button_Primary.prefab`
+- `Assets/UI/Common/Prefabs/Buttons/Variants/UI_Common_Button_Primary_Selected.prefab`
+- `Assets/UI/Screens/Inventory/Prefabs/UI_Inventory_ItemCardHost.prefab`
+
+## 7. Placeholder Rules
+
+Placeholders are allowed, but they must stay easy to replace.
+
+- Put placeholders in a clearly provisional folder when possible.
+- Use `Placeholder` in the asset name when the visual is intentionally temporary.
+- Do not let placeholder assets silently become permanent shared assets.
+
+Examples:
+
+- `UI_Inventory_Placeholder_ItemIcon`
+- `UI_Popup_Placeholder_Background`
+
+## 8. Anti-Patterns
+
+Avoid these:
+
+- putting one-screen assets into `Common` too early
+- storing reusable prefabs inside one random screen folder
+- naming assets by coordinates or resolution
+- mixing several naming styles for the same asset family
+- leaving extracted reusable assets with clone or copy names
+- turning placeholder assets into de facto design-system assets without cleanup
+
+## 9. Review Questions
+
+Ask:
+
+- If this asset were needed again next week, would another agent know where to look?
+- Does the name reveal what the asset is and whether it is shared or screen-scoped?
+- Is the folder location consistent with the intended reuse boundary?
+- Did we create a shared asset only because it is actually shared?
+- Are placeholder assets still visibly marked as provisional?
+
+If the answer is no, rename or relocate the asset before calling the work done.

--- a/unity-mcp-ui-layout/references/common-failures.md
+++ b/unity-mcp-ui-layout/references/common-failures.md
@@ -228,7 +228,28 @@ This document is organized by symptom first, because that is usually how problem
 - then check sprite-backed visuals, text styles, and materials
 - leave placeholders as a deliberate last resort, not a default first step
 
-## 12. Quick Recovery Strategy
+## 12. New Assets Are Named and Stored Like Scratch Files
+
+### Typical symptoms
+
+- reusable assets are left as `Copy`, `New`, or `Temp`
+- shared widgets are buried inside one random screen folder
+- placeholder visuals start looking like permanent design-system assets
+
+### Likely causes
+
+- asset creation focused only on today's task, not future rediscovery
+- shared versus screen-owned scope was never decided
+- assets were extracted quickly but never normalized into a stable folder shape
+
+### Fix direction
+
+- rename assets by role instead of editor history
+- move shared assets into stable shared UI folders
+- keep screen-owned assets near the screen that owns them
+- keep placeholder assets visibly provisional so later replacement stays easy
+
+## 13. Quick Recovery Strategy
 
 When the work starts drifting, reset the process:
 

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -157,6 +157,16 @@ Check reusable prefabs first, then variant or wrapper paths, then existing sprit
 Do not jump straight to placeholder-driven reconstruction while obvious reusable assets still exist.
 ```
 
+## Pattern 9C: Name and Place Assets Deliberately
+
+Use when asset-aware mode creates or promotes UI assets during the task.
+
+```text
+If this work creates, extracts, or promotes UI assets, name and place them deliberately.
+Keep shared assets in predictable shared UI folders, keep screen-owned assets near the screen that owns them, and keep placeholder assets visibly provisional.
+Do not leave reusable assets with clone, copy, temp, or coordinate-based names.
+```
+
 ## Pattern 10: UGUI HUD Build
 
 Use when building or repairing a HUD.

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -70,7 +70,18 @@ Ask:
 
 If the answer is no, convert the asset usage back toward the normal sprite workflow before calling the UI done.
 
-## 7. Text Check
+## 7. Asset Naming and Placement Check
+
+Ask:
+
+- Were newly created or promoted assets given names that reveal role clearly?
+- Are shared assets stored in shared UI folders and screen-owned assets stored near the screen that owns them?
+- Are placeholder assets still visibly marked as provisional instead of looking like stable shared assets?
+- Would another agent be able to rediscover the asset family without guessing?
+
+If the answer is no, rename or relocate the assets before calling the UI done.
+
+## 8. Text Check
 
 Ask:
 
@@ -80,7 +91,7 @@ Ask:
 
 Text problems should be treated as layout problems first, not only font-size problems.
 
-## 8. Interaction Area Check
+## 9. Interaction Area Check
 
 Ask:
 
@@ -90,7 +101,7 @@ Ask:
 
 This check is especially important for popup and mobile layouts.
 
-## 9. Safe Area Check
+## 10. Safe Area Check
 
 Ask:
 
@@ -100,7 +111,7 @@ Ask:
 
 If safe area works only because several children have manual offsets, the design still needs cleanup.
 
-## 10. Visual Consistency Check
+## 11. Visual Consistency Check
 
 Ask:
 
@@ -110,7 +121,7 @@ Ask:
 
 This is where hand-placed designs usually reveal themselves.
 
-## 11. Scope Check
+## 12. Scope Check
 
 Ask:
 
@@ -121,7 +132,7 @@ Ask:
 
 If the answer is no, narrow the change before shipping it.
 
-## 12. Final Go/No-Go Rule
+## 13. Final Go/No-Go Rule
 
 Do not call the UI complete unless:
 


### PR DESCRIPTION
## 요약\n- 자산 네이밍과 폴더 규칙 문서 추가\n- 공유 자산과 화면 전용 자산의 배치 기준 정리\n- 검수/실패 패턴/프롬프트 패턴/README 반영\n\n## 상세\n- sset-aware mode에서 새로 만들거나 추출한 UI 자산을 이후 에이전트도 다시 찾기 쉽게 만드는 규칙을 추가했습니다.\n- 공유 자산은 Assets/UI/Common/..., 화면 전용 자산은 Assets/UI/Screens/<ScreenName>/...처럼 예측 가능한 구조를 권장합니다.\n- Copy, New, 좌표/해상도 기반 이름 대신 역할 중심 이름을 사용하도록 했습니다.\n- Placeholder 자산은 임시 상태가 드러나도록 별도 규칙을 추가했습니다.\n\n## 검증\n- 로컬 스킬 검증 통과\n- 전역 스킬 동기화 및 검증 통과