### PR TITLE
텍스트 레이아웃 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Platform-specific adapters live in:
 - repair mode vs greenfield build mode rules for existing-screen fixes versus new UI creation
 - asset discovery priority rules for prefab, sprite, font, material, and placeholder reuse order
 - asset naming and folder rules so reusable assets stay discoverable and screen-owned assets stay scoped correctly
+- text layout rules for wrapping, truncation, auto-size discipline, counters, and localization headroom
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -74,6 +75,7 @@ Platform-specific adapters live in:
 - 기존 UI 수정 요청과 신규 UI 생성 요청을 구분하는 작업 모드 규칙
 - 프리팹, 스프라이트, 폰트, 머티리얼, 플레이스홀더를 어떤 순서로 찾을지에 대한 자산 탐색 우선순위 규칙
 - 재사용 자산은 다시 찾기 쉽고 화면 전용 자산은 범위가 드러나도록 만드는 자산 네이밍/폴더 규칙
+- 줄바꿈, truncation, auto-size 절제, 숫자 영역, 지역화 여유를 위한 텍스트 레이아웃 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -30,7 +30,9 @@ Read the current context before making changes.
 - Check editor readiness through `editor_state` or equivalent resources.
 - Find the active scene, existing UI roots, and relevant cameras.
 - For UGUI, inspect `Canvas`, `CanvasScaler`, parent `RectTransform`, active layout components, and safe-area handling before changing child objects.
+- For text-heavy UGUI, also inspect `TextMeshProUGUI`, wrapping and overflow behavior, preferred width/height assumptions, and any existing TMP style patterns before resizing containers.
 - For UI Toolkit, find the active `UIDocument`, linked `UXML`, linked `USS`, and panel settings before editing styles.
+- For text-heavy UI Toolkit, inspect text roles, width rules, overflow behavior, and reusable USS text classes before applying local overrides.
 - If the user provides a layout image and target resolution, treat them as the source spec for composition before creating any objects.
 - If the user provides a layout image but no explicit target resolution, capture the image's native resolution and treat that as the initial reference frame.
 
@@ -127,6 +129,8 @@ Use screenshots aggressively.
 - Do not decompose a likely single-image asset into fake sub-shapes unless interaction, animation, or dynamic layout actually requires separate elements.
 - For static UI visuals, prefer `Image` plus sprite-based assets. Reserve `RawImage` for true texture-driven content such as `RenderTexture`, video, or runtime-generated textures.
 - Treat text as a layout driver. Check wrapping, overflow, best-fit/auto-size, and font asset limits before resizing containers.
+- Decide whether important text should wrap, truncate, stay single-line, or grow its container before shrinking fonts.
+- Leave reasonable headroom for longer labels, dynamic values, and likely localization growth instead of trusting mockup string lengths literally.
 - For UI Toolkit, prefer USS classes and container rules over many inline style overrides.
 - If the user gives only a visual description, assume one target resolution first, implement for that resolution, then test at additional aspect ratios.
 - If the screen looks crowded, reduce hierarchy complexity and nesting depth before adding more overrides.
@@ -158,6 +162,7 @@ Use screenshots aggressively.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.
 - Read `references/review-checks.md` when you need a final quality pass before calling a Unity UI task complete.
 - Read `references/sprite-vs-rawimage.md` when static UI assets are being wired through `RawImage` instead of the normal sprite workflow.
+- Read `references/text-layout-rules.md` when text length, wrapping, overflow, auto-size, counters, or localization safety are driving layout instability.
 - Read `references/ugui-anchors-canvas-scaler.md` when the target is UGUI or when anchor, pivot, or screen-scaling behavior is causing drift.
 - Read `references/ugui-hud.md` for always-on-screen HUD, minimap, status bars, and action bars.
 - Read `references/ugui-inventory.md` for slot grids, item lists, equipment panels, and shop layouts.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -18,6 +18,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `prefab-variants.md`
 - `prefab-reuse.md`
 - `sprite-vs-rawimage.md`
+- `text-layout-rules.md`
 - `common-failures.md`
 - `review-checks.md`
 

--- a/unity-mcp-ui-layout/references/common-failures.md
+++ b/unity-mcp-ui-layout/references/common-failures.md
@@ -249,7 +249,30 @@ This document is organized by symptom first, because that is usually how problem
 - keep screen-owned assets near the screen that owns them
 - keep placeholder assets visibly provisional so later replacement stays easy
 
-## 13. Quick Recovery Strategy
+## 13. Text Is Forced to Fit Instead of Being Designed to Fit
+
+### Typical symptoms
+
+- button labels become tiny just to stay on one line
+- counters overlap icons when values grow
+- one localized string breaks a row that looked fine in the mockup
+- text auto-size hides the issue at one resolution but fails at another
+
+### Likely causes
+
+- text line behavior was never decided explicitly
+- container width was copied from the mockup without runtime headroom
+- font shrinking was used before fixing parent width or sibling layout
+- reusable text styles were ignored in favor of local emergency tweaks
+
+### Fix direction
+
+- decide whether the text should wrap, truncate, stay single-line, or grow its container
+- stabilize the parent width and sibling layout first
+- leave headroom for longer labels and runtime number growth
+- use font shrinking only as a controlled final adjustment, not as the default structural fix
+
+## 14. Quick Recovery Strategy
 
 When the work starts drifting, reset the process:
 

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -117,6 +117,18 @@ Keep decorative regions whole unless interaction, animation, dynamic text, or ad
 Turn repeated structures into reusable prefabs or reusable layout blocks instead of rebuilding them manually.
 ```
 
+## Pattern 19: Stabilize Text Before Shrinking Fonts
+
+Use when labels, counters, or descriptions are breaking the layout.
+
+```text
+Treat text as a layout driver for this task.
+Inspect the parent width rule, wrapping behavior, overflow mode, and reusable text styles first.
+Decide explicitly whether each important text region should stay single-line, wrap, truncate, or grow its container.
+Only reduce font size after the container and sibling layout rules are already stable.
+Leave reasonable headroom for slightly longer labels or runtime value growth.
+```
+
 ## Pattern 8: Script-Aware UI Editing
 
 Use when script changes are necessary.

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -88,6 +88,9 @@ Ask:
 - Is any text clipped, wrapping incorrectly, or causing row expansion?
 - Are button labels visually balanced?
 - Would the current layout likely survive slightly longer strings?
+- Was line behavior chosen deliberately for major text roles instead of left to defaults?
+- Are counters, currencies, and dynamic values given enough room for realistic growth?
+- Did we solve the text issue by fixing layout first instead of immediately shrinking fonts?
 
 Text problems should be treated as layout problems first, not only font-size problems.
 

--- a/unity-mcp-ui-layout/references/text-layout-rules.md
+++ b/unity-mcp-ui-layout/references/text-layout-rules.md
@@ -1,0 +1,141 @@
+# Text Layout Rules
+
+Use this guide when text is likely to drive layout quality: buttons, headers, tabs, inventory rows, settings labels, popup bodies, counters, and localized UI.
+
+The main rule is simple:
+
+- treat text as a layout driver
+- do not treat text overflow as a last-minute font-size problem
+
+## 1. Decide the Text Role First
+
+Before changing sizes, decide what the text is supposed to be.
+
+Typical roles:
+
+- title
+- section header
+- body copy
+- button label
+- tab label
+- value or counter
+- item name
+- description text
+
+Each role should have a different tolerance for wrapping, truncation, scaling, and container growth.
+
+## 2. Choose Line Behavior Explicitly
+
+Do not leave line behavior to defaults.
+
+For each important text region, decide one of these first:
+
+- single line only
+- wrap to multiple lines
+- truncate or ellipsis
+- expand parent row or container
+
+Examples:
+
+- popup title: usually single line or controlled two-line cap
+- body description: usually wraps
+- tab label: usually single line and width-constrained
+- number display: usually single line with stable alignment
+- inventory item name: often one or two lines depending on design
+
+## 3. Size the Container Before Shrinking the Text
+
+When text breaks layout:
+
+1. inspect the parent width rule
+2. inspect padding and spacing
+3. inspect whether sibling layout is stable
+4. only then consider font size changes
+
+Auto-size can hide a structural problem for one resolution and reintroduce it later.
+
+## 4. Prefer Reusable Text Styles
+
+If asset-aware mode is active:
+
+- reuse existing TMP styles or text presentation rules before inventing new ones
+- keep title, body, caption, and number systems consistent across screens
+
+Even in layout-only mode:
+
+- do not create random one-off text settings for every widget
+- prefer a small number of repeatable text patterns
+
+## 5. Rules for Button and Tab Labels
+
+Buttons and tabs often fail because text is treated as decorative instead of structural.
+
+- Give labels a stable container width rule.
+- Do not rely on extreme auto-size ranges to force every string into one tiny button.
+- If labels vary, let the button family define a minimum width and an acceptable expansion strategy.
+- Keep visual balance across sibling buttons.
+
+If one button becomes much wider than its siblings, check whether the layout should wrap, align, or split actions differently.
+
+## 6. Rules for Numeric Text
+
+Counters, currency, timers, and stat values need stable rhythm.
+
+- Prefer fixed alignment rules.
+- Anticipate digit growth.
+- Keep enough width for realistic value changes.
+- Do not place number text in containers sized only for the mockup's smallest visible value.
+
+If the value can grow at runtime, the container must acknowledge that.
+
+## 7. Localized and Long-String Safety
+
+A layout that works only for one short string is not stable.
+
+Before calling text layout done, ask:
+
+- would this still work with a slightly longer string?
+- would another language likely overflow?
+- is the current success dependent on unusually short English text?
+
+You do not need full localization coverage for every task, but you should leave reasonable headroom where the role obviously needs it.
+
+## 8. UGUI Guidance
+
+For UGUI:
+
+- inspect `TextMeshProUGUI` overflow and wrapping rules deliberately
+- avoid mixing parent-driven layout with desperate font auto-size as the primary fix
+- use layout groups and preferred widths thoughtfully for text-heavy rows
+- keep text padding in the parent when possible instead of many child offsets
+
+## 9. UI Toolkit Guidance
+
+For UI Toolkit:
+
+- prefer reusable USS classes for text roles
+- keep width, flex behavior, and overflow rules predictable
+- avoid scattered inline overrides for text sizing unless the case is truly local
+
+## 10. Anti-Patterns
+
+Avoid these:
+
+- shrinking text first without checking container ownership
+- using huge auto-size ranges as the default solution
+- letting every label choose its own random font settings
+- designing buttons around one short string only
+- trusting mockup text length as a hard runtime truth
+- ignoring number growth in counters and currencies
+
+## 11. Review Questions
+
+Ask:
+
+- Did we decide line behavior explicitly for important text regions?
+- Are text containers sized by role rather than by the shortest visible sample?
+- Would slightly longer labels still fit acceptably?
+- Are reusable text styles being preserved where the project already has them?
+- Did we solve layout with structure first and font shrinking second?
+
+If the answer is no, the UI is probably still fragile.


### PR DESCRIPTION
## 요약\n- 텍스트 레이아웃 전용 가이드 추가\n- 텍스트 관련 실패 패턴과 검수 항목 보강\n- 프롬프트 패턴 및 README 반영\n\n## 상세\n- 텍스트를 마지막 폰트 조정이 아니라 레이아웃 드라이버로 다루는 규칙을 추가했습니다.\n- 주요 텍스트 역할에 대해 single-line, wrap, truncate, container growth를 먼저 결정하도록 했습니다.\n- 버튼 라벨, 탭, 설명문, 숫자 카운터, 지역화 여유를 포함한 텍스트 안정성 기준을 정리했습니다.\n- 폰트 축소는 구조 안정화 이후의 마지막 수단으로 제한했습니다.\n\n## 검증\n- 로컬 스킬 검증 통과\n- 전역 스킬 동기화 및 검증 통과