### PR TITLE
최종 보강 가이드와 예시 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Platform-specific adapters live in:
 - asset discovery priority rules for prefab, sprite, font, material, and placeholder reuse order
 - asset naming and folder rules so reusable assets stay discoverable and screen-owned assets stay scoped correctly
 - text layout rules for wrapping, truncation, auto-size discipline, counters, and localization headroom
+- safe-area remapping rules for mobile mockups that do not visibly account for notches or home indicators
+- shared asset edit safety rules for deciding when direct base edits are too risky
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -76,6 +78,8 @@ Platform-specific adapters live in:
 - 프리팹, 스프라이트, 폰트, 머티리얼, 플레이스홀더를 어떤 순서로 찾을지에 대한 자산 탐색 우선순위 규칙
 - 재사용 자산은 다시 찾기 쉽고 화면 전용 자산은 범위가 드러나도록 만드는 자산 네이밍/폴더 규칙
 - 줄바꿈, truncation, auto-size 절제, 숫자 영역, 지역화 여유를 위한 텍스트 레이아웃 규칙
+- 노치/홈 인디케이터가 없는 시안을 모바일 safe area 안쪽 여백으로 재해석하는 규칙
+- 공용 prefab/sprite/material/text style에 대한 직접 수정이 위험한지 판단하는 안전 규칙
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,9 @@ Use these files when you want a copyable starting point instead of only referenc
 - `hud-example.md`
 - `inventory-example.md`
 - `mockup-resolution-example.md`
+- `mobile-safe-area-mockup-example.md`
 - `popup-safe-area-example.md`
+- `shared-asset-safety-example.md`
 
 ## How to Use
 
@@ -30,4 +32,6 @@ Use these files when you want a copyable starting point instead of only referenc
 1. `hud-example.md` if you are starting with a composition-driven overlay
 2. `inventory-example.md` if your UI is slot- or list-based
 3. `mockup-resolution-example.md` if the mockup's native pixel resolution should drive planning
-4. `popup-safe-area-example.md` if mobile safe area and modal structure matter
+4. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
+5. `popup-safe-area-example.md` if mobile safe area and modal structure matter
+6. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets

--- a/examples/mobile-safe-area-mockup-example.md
+++ b/examples/mobile-safe-area-mockup-example.md
@@ -1,0 +1,24 @@
+# Mobile Safe Area Mockup Example
+
+Use this example when the provided mockup does not visibly account for a notch or home indicator, but the real target is a mobile safe-area layout.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to build this mobile popup from the attached mockup.
+Treat the mockup as a composition reference, not as raw unsafe edge geometry.
+Apply safe-area ownership to PopupRoot, remap top and bottom spacing inside the safe area, and verify both portrait and landscape.
+Keep the dimmer full-screen, but keep popup content local to PopupRoot.
+```
+
+## Why This Works
+
+- It tells the agent that the mockup is composition-first.
+- It prevents raw top and bottom pixel copying.
+- It forces safe-area ownership to stay on the correct parent.
+
+## Suggested References
+
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\mockup-safe-area-mapping.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\ugui-mobile-safe-area.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\ugui-popup.md`

--- a/examples/shared-asset-safety-example.md
+++ b/examples/shared-asset-safety-example.md
@@ -1,0 +1,24 @@
+# Shared Asset Safety Example
+
+Use this example when the requested change might touch a common prefab, sprite, material, or TMP style that is reused across multiple screens.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to repair this inventory row without destabilizing shared assets.
+Inspect whether the current widget is a shared prefab family first.
+If the requested change is screen-specific, prefer a variant, wrapper, or local override instead of editing the shared base directly.
+Only edit the shared asset itself if you can justify that the change should apply across its other usages too.
+```
+
+## Why This Works
+
+- It forces a scope decision before editing.
+- It reduces accidental shared-base regressions.
+- It keeps one-screen repairs from leaking into the design system.
+
+## Suggested References
+
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\shared-asset-edit-safety.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\existing-prefab-reuse.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\prefab-variants.md`

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -52,6 +52,7 @@ After the initial scene/editor inspection, run a quick capability check before p
 - If asset-aware mode is warranted and both `unity-resource-rag` and an asset catalog or asset index are available, look for matching reusable assets before building replacements from scratch.
 - In asset-aware mode, follow a stable discovery order: reusable prefabs first, then variants or wrappers, then sprite-backed visuals, then text styles, then materials, and placeholders last.
 - In asset-aware mode, name and place any new reusable assets deliberately so future discovery stays predictable: shared assets should read as shared, screen-specific assets should stay near the screen that owns them, and placeholder assets should stay visibly provisional.
+- Before directly editing an existing shared asset family, decide whether the change really belongs in the shared base or should stay local through a variant, wrapper, or screen-owned override.
 - If asset-aware mode is warranted but `unity-resource-rag` is unavailable, continue with image-to-layout translation using the existing layout rules, preserve structure-first execution, use placeholder visuals or existing manually discovered assets, and explicitly state that asset-aware retrieval was skipped.
 - If asset-aware mode is warranted and `unity-resource-rag` is available but retrieval confidence is low, do not force an asset match, keep the layout workflow moving, mark visuals as provisional, and verify structure first.
 - Missing or low-confidence asset-RAG capability is not a hard blocker unless the user explicitly requires asset-index-backed reuse.
@@ -145,6 +146,7 @@ Use screenshots aggressively.
 - Re-check at one narrow aspect ratio and one wide aspect ratio before calling the layout done.
 - If the project appears mobile-first, verify portrait and landscape separately.
 - Use visual comparison language in follow-up steps: aligned, clipped, stretched, overflowing, uneven, off-safe-area.
+- If a mobile mockup appears notch-agnostic, preserve its composition inside the safe area instead of copying raw top and bottom edge pixels from the image.
 
 ## Use the References
 
@@ -161,7 +163,9 @@ Use screenshots aggressively.
 - Read `references/prefab-variants.md` when one shared base prefab should branch into a controlled family of variants without polluting the base asset.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.
 - Read `references/review-checks.md` when you need a final quality pass before calling a Unity UI task complete.
+- Read `references/shared-asset-edit-safety.md` when a one-screen request might tempt you to edit a shared prefab, sprite, material, or text style directly.
 - Read `references/sprite-vs-rawimage.md` when static UI assets are being wired through `RawImage` instead of the normal sprite workflow.
+- Read `references/mockup-safe-area-mapping.md` when a mobile mockup did not visibly account for safe area but the runtime layout must.
 - Read `references/text-layout-rules.md` when text length, wrapping, overflow, auto-size, counters, or localization safety are driving layout instability.
 - Read `references/ugui-anchors-canvas-scaler.md` when the target is UGUI or when anchor, pivot, or screen-scaling behavior is causing drift.
 - Read `references/ugui-hud.md` for always-on-screen HUD, minimap, status bars, and action bars.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -15,8 +15,10 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `asset-discovery-priority.md`
 - `asset-naming-and-folders.md`
 - `existing-prefab-reuse.md`
+- `shared-asset-edit-safety.md`
 - `prefab-variants.md`
 - `prefab-reuse.md`
+- `mockup-safe-area-mapping.md`
 - `sprite-vs-rawimage.md`
 - `text-layout-rules.md`
 - `common-failures.md`

--- a/unity-mcp-ui-layout/references/common-failures.md
+++ b/unity-mcp-ui-layout/references/common-failures.md
@@ -272,7 +272,49 @@ This document is organized by symptom first, because that is usually how problem
 - leave headroom for longer labels and runtime number growth
 - use font shrinking only as a controlled final adjustment, not as the default structural fix
 
-## 14. Quick Recovery Strategy
+## 14. A One-Screen Fix Quietly Damages a Shared Asset
+
+### Typical symptoms
+
+- a common button or row suddenly looks different in several unrelated screens
+- one local popup fix changes spacing across the whole UI family
+- a shared material or text style becomes slightly wrong everywhere after a targeted repair
+
+### Likely causes
+
+- a shared base asset was edited for a local need
+- a variant or wrapper should have been used instead
+- the impact radius of the direct edit was never checked
+
+### Fix direction
+
+- identify whether the asset is truly shared
+- revert risky direct edits if the change is only local
+- move the difference into a variant, wrapper, or screen-owned asset
+- verify at least one other usage before accepting a direct shared-base edit
+
+## 15. The Mobile Result Copies Unsafe Mockup Edges Too Literally
+
+### Typical symptoms
+
+- top controls sit too close to the notch
+- bottom CTA rows feel crushed against the home indicator
+- the hierarchy matches the mockup visually, but the runtime screen feels unsafe or cramped
+
+### Likely causes
+
+- a notch-free mockup was treated like raw device-edge geometry
+- safe area was applied late as a patch instead of as a layout boundary
+- edge spacing was copied from the image instead of remapped into the safe area
+
+### Fix direction
+
+- treat the mockup as composition guidance
+- apply safe area at the correct parent first
+- rebuild top and bottom spacing relative to the safe-area-owned container
+- verify portrait and landscape instead of trusting the flat mockup image alone
+
+## 16. Quick Recovery Strategy
 
 When the work starts drifting, reset the process:
 

--- a/unity-mcp-ui-layout/references/mockup-safe-area-mapping.md
+++ b/unity-mcp-ui-layout/references/mockup-safe-area-mapping.md
@@ -1,0 +1,106 @@
+# Mockup to Safe Area Mapping
+
+Use this guide when a mockup or screenshot was designed without device cutouts, but the implementation target is a mobile screen that must respect safe area constraints.
+
+The goal is not to copy the mockup's raw top and bottom pixels.
+The goal is to preserve the intended composition while reinterpreting edge spacing inside the safe area.
+
+## 1. Core Rule
+
+When a mockup has no notch or home-indicator constraints:
+
+- treat the mockup as a composition reference
+- treat the device safe area as the implementation boundary
+- remap edge spacing into the safe area instead of preserving raw screen-edge distance
+
+Do not keep a header "40 px from the physical top of the screen" if that would push it into unsafe space.
+
+## 2. Separate Two Spaces
+
+Always think in two spaces:
+
+```mermaid
+flowchart TD
+    A["Mockup composition space"] --> B["Normalized spacing intent"]
+    B --> C["Safe-area-aware implementation space"]
+```
+
+- Mockup space tells you the intended hierarchy and spacing rhythm.
+- Safe-area-aware implementation space tells you where the runtime UI may actually live.
+
+## 3. Reinterpret Edge Distance, Do Not Copy It
+
+If the mockup shows:
+
+- a top bar 36 px below the top edge
+- a bottom action row 28 px above the bottom edge
+
+Do not blindly preserve those exact edge distances on a phone with a notch or home indicator.
+
+Instead:
+
+1. identify the owning parent container
+2. apply safe area at the correct parent
+3. preserve the mockup's internal spacing rhythm inside that parent
+
+That means the top bar becomes "36 px below the top of the safe area-owned container", not "36 px below the physical screen edge".
+
+## 4. Safe Area Ownership Rules
+
+- Full-screen mobile UI: safe area usually belongs on `SafeAreaRoot`
+- Modal popup: safe area belongs on `PopupRoot`
+- Do not distribute safe area compensation across many leaf widgets
+- Do not combine one global safe-area owner with several manual child corrections unless the design truly requires it
+
+## 5. What Stays Stable From the Mockup
+
+Keep these stable where possible:
+
+- top/bottom/left/right/center ownership
+- section hierarchy
+- relative spacing within a cluster
+- modal composition balance
+- button grouping rhythm
+
+These survive the mapping better than raw edge pixels.
+
+## 6. What Must Adapt
+
+These often need reinterpretation:
+
+- top banners near the notch
+- bottom CTA bars near the home indicator
+- close buttons in popup corners
+- decorative edge art that assumes a rectangular full screen
+- ultra-tight top or bottom padding copied from the mockup
+
+## 7. Practical Workflow
+
+When implementing from a mobile mockup:
+
+1. capture the mockup resolution
+2. identify whether the mockup visibly includes device safe area constraints
+3. if not, mark it as notch-agnostic composition
+4. decide the correct safe-area owner
+5. rebuild edge spacing relative to the safe-area owner, not the physical screen edge
+6. verify both portrait and landscape if the product is expected to support both
+
+## 8. Anti-Patterns
+
+Avoid these:
+
+- preserving raw top-edge pixels from a notch-free mockup on a notched phone
+- applying safe area once globally and then compensating again on each top control
+- leaving popup close buttons aligned to unsafe corners because the mockup looked clean there
+- treating the safe area like an optional polish pass after all placement is done
+
+## 9. Review Questions
+
+Ask:
+
+- Was the mockup interpreted as composition guidance rather than raw device-edge geometry?
+- Does safe area ownership belong to one correct parent instead of many children?
+- Were top and bottom edge distances remapped into the safe area correctly?
+- Does the mobile result preserve the mockup's visual hierarchy even though absolute edge pixels changed?
+
+If the answer is no, the layout is probably still overfit to the mockup image instead of the real device boundary.

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -129,6 +129,27 @@ Only reduce font size after the container and sibling layout rules are already s
 Leave reasonable headroom for slightly longer labels or runtime value growth.
 ```
 
+## Pattern 20: Map a Notch-Agnostic Mockup Into Safe Area
+
+Use when a mobile mockup looks like a clean rectangle but the real target device has a notch or home indicator.
+
+```text
+Treat the mockup as composition guidance, not as raw unsafe edge geometry.
+Identify the correct safe-area owner first, then remap top and bottom spacing inside that safe-area-owned container.
+Preserve the mockup's hierarchy and spacing rhythm, but do not preserve raw top or bottom edge pixels if that would place controls into unsafe areas.
+Verify portrait and landscape when the target product supports both.
+```
+
+## Pattern 21: Avoid Risky Shared Asset Base Edits
+
+Use when the requested change may touch a common prefab, sprite, material, or TMP style.
+
+```text
+Inspect whether this change targets a truly shared asset family before editing it.
+If the request is one-screen or one-flow specific, prefer a variant, wrapper, or local override instead of editing the shared base directly.
+Only edit the shared asset when the change clearly belongs to the common contract and would make sense across other usages too.
+```
+
 ## Pattern 8: Script-Aware UI Editing
 
 Use when script changes are necessary.

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -111,6 +111,7 @@ Ask:
 - Are top and bottom edge controls inside the safe area?
 - Is safe-area ownership applied only once at the correct container?
 - For popups, is safe area owned by `PopupRoot` rather than the dimmer or individual children?
+- If the mockup was notch-agnostic, did we reinterpret edge spacing inside the safe area instead of copying raw top and bottom pixels?
 
 If safe area works only because several children have manual offsets, the design still needs cleanup.
 
@@ -132,6 +133,7 @@ Ask:
 - Were unrelated screens or widgets changed unnecessarily?
 - Was the original style preserved when the request was a repair?
 - Did we stay in the correct operating mode: bounded repair for fixes, or build mode for true greenfield work?
+- If an existing shared asset was edited directly, was that scope truly justified?
 
 If the answer is no, narrow the change before shipping it.
 

--- a/unity-mcp-ui-layout/references/shared-asset-edit-safety.md
+++ b/unity-mcp-ui-layout/references/shared-asset-edit-safety.md
@@ -1,0 +1,114 @@
+# Shared Asset Edit Safety
+
+Use this guide when the requested UI change touches assets that might be shared across screens.
+
+This includes:
+
+- shared prefabs
+- prefab families
+- common sprites
+- shared materials
+- TMP styles or font presentation assets
+
+The goal is to avoid solving a one-screen task by destabilizing a shared asset family.
+
+## 1. Core Decision
+
+Before editing an existing shared asset, decide which of these is safest:
+
+1. direct shared-asset edit
+2. variant or wrapper
+3. local screen-owned override
+4. new asset family
+
+Do not assume direct editing is the default.
+
+## 2. When Direct Edit Is Reasonable
+
+Direct shared-asset edit is acceptable only when:
+
+- the requested change clearly improves the shared base contract
+- the change is intended for all known usages
+- the visual or structural shift is small and consistent with the design system
+- there is no obvious screen-specific behavior being pushed into the base
+
+Examples:
+
+- fixing a genuinely broken shared padding rule
+- correcting a shared icon alignment bug
+- improving a shared button text inset that is wrong everywhere
+
+## 3. When Direct Edit Is Risky
+
+Direct shared-asset edit is risky when:
+
+- the user asked for a one-screen repair
+- the requested layout difference is screen-specific
+- the change adds or removes optional sections only one screen needs
+- the base asset is already used by several families
+- the impact radius is unknown
+
+In those cases, prefer variant, wrapper, or local screen-owned composition.
+
+## 4. Variant vs Wrapper
+
+Use a variant when:
+
+- the base structure is right
+- only scoped visuals or optional sections differ
+- the base contract should remain intact
+
+Use a wrapper when:
+
+- the screen needs extra surrounding layout
+- the base widget should stay unchanged inside a screen-specific host
+- screen-level positioning or composition should not pollute the shared base
+
+## 5. Shared Non-Prefab Assets
+
+Apply similar caution to:
+
+### Sprites
+
+- Do not replace a shared sprite asset just to satisfy one screen's temporary art need.
+- Prefer a screen-owned sprite or a placeholder replacement path if the design is not final.
+
+### Materials
+
+- Do not mutate a common UI material for one popup effect if other screens rely on it.
+- Prefer a duplicated or screen-owned material when the visual treatment is local.
+
+### TMP Styles or Font Assets
+
+- Do not push one screen's emergency size tweak into a common text style unless the shared text system really should change everywhere.
+- Prefer local style application or a new named style when the role differs.
+
+## 6. Verification Before Direct Edit
+
+Before directly editing a shared asset, try to verify at least one additional known usage.
+
+If another usage cannot be checked:
+
+- treat the edit as higher risk
+- bias toward variant, wrapper, or local override unless the change is clearly global
+
+## 7. Anti-Patterns
+
+Avoid these:
+
+- fixing one popup by editing the common button base for every screen
+- editing a shared sprite just because it is already loaded in the scene
+- using a shared material as a scratch pad for local experimentation
+- changing a common TMP style to rescue one crowded row
+
+## 8. Review Questions
+
+Ask:
+
+- Is this asset truly shared?
+- Is the requested change truly shared?
+- Would another screen be surprised by this edit?
+- Should this be a variant, wrapper, or local override instead?
+- Did we verify another usage before editing the shared base directly?
+
+If those answers are unclear, direct base edit is probably too risky.


### PR DESCRIPTION
## 요약\n- 모바일 safe area와 시안 매핑 규칙 추가\n- 공용 자산 직접 수정 안전 규칙 추가\n- 관련 실전 예시 문서 추가\n\n## 상세\n- 노치나 홈 인디케이터가 없는 시안을 모바일 safe area 안쪽 여백으로 재해석하는 규칙을 추가했습니다.\n- 공용 prefab/sprite/material/TMP style을 직접 수정할지, variant/wrapper/local override로 갈지 판단하는 안전 규칙을 추가했습니다.\n- 이 두 규칙을 바로 복사해 쓸 수 있도록 예시 문서도 추가했습니다.\n- SKILL, references index, prompt patterns, common failures, review checks, examples index, root README를 함께 갱신했습니다.\n\n## 검증\n- 로컬 스킬 검증 통과\n- 전역 스킬 동기화 및 검증 통과