### PR TITLE
UI Toolkit 심화 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Platform-specific adapters live in:
 - text layout rules for wrapping, truncation, auto-size discipline, counters, and localization headroom
 - safe-area remapping rules for mobile mockups that do not visibly account for notches or home indicators
 - shared asset edit safety rules for deciding when direct base edits are too risky
+- UI Toolkit container ownership, flex stability, and text overflow guidance
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
 - final review checks before calling a UI task done
@@ -80,6 +81,7 @@ Platform-specific adapters live in:
 - 줄바꿈, truncation, auto-size 절제, 숫자 영역, 지역화 여유를 위한 텍스트 레이아웃 규칙
 - 노치/홈 인디케이터가 없는 시안을 모바일 safe area 안쪽 여백으로 재해석하는 규칙
 - 공용 prefab/sprite/material/text style에 대한 직접 수정이 위험한지 판단하는 안전 규칙
+- UI Toolkit 화면에서 container ownership, flex 안정성, text overflow를 다루는 가이드
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드
 - 작업 완료 전에 보는 최종 검수 체크

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - `mobile-safe-area-mockup-example.md`
 - `popup-safe-area-example.md`
 - `shared-asset-safety-example.md`
+- `ui-toolkit-example.md`
 
 ## How to Use
 
@@ -35,3 +36,4 @@ Use these files when you want a copyable starting point instead of only referenc
 4. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
 5. `popup-safe-area-example.md` if mobile safe area and modal structure matter
 6. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
+7. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/ui-toolkit-example.md
+++ b/examples/ui-toolkit-example.md
@@ -1,0 +1,26 @@
+# UI Toolkit Example
+
+Use this example when the target screen is clearly built with `UIDocument`, `UXML`, `USS`, and `VisualElement`.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to repair this UI Toolkit settings screen.
+Inspect the current UIDocument, UXML, USS, and visual tree first.
+Keep layout ownership in containers, not leaf elements.
+Clarify which regions own flex direction, width, overflow, and scroll behavior.
+If text is breaking the layout, decide whether it should wrap, truncate, or grow its container before shrinking fonts.
+Verify the result at the main target width and one narrower width.
+```
+
+## Why This Works
+
+- It forces discovery before styling changes.
+- It treats flex ownership as a container problem first.
+- It treats text behavior as a structural decision.
+
+## Suggested References
+
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\ui-toolkit-layout-rules.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\ui-toolkit-failures.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\text-layout-rules.md`

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -20,6 +20,7 @@ Identify the target before editing:
 For UGUI, prefer `find_gameobjects`, `manage_gameobject`, `manage_components`, `manage_scene`, `manage_prefabs`, `manage_script`, `manage_camera`, `refresh_unity`, and `read_console`.
 
 For UI Toolkit, prefer `manage_ui`, `manage_script`, `find_in_file`, `manage_camera`, `refresh_unity`, and `read_console`.
+For UI Toolkit work, prefer stabilizing `UXML` structure, `USS` classes, and container ownership before adding many inline style patches.
 
 ## Workflow
 
@@ -32,6 +33,7 @@ Read the current context before making changes.
 - For UGUI, inspect `Canvas`, `CanvasScaler`, parent `RectTransform`, active layout components, and safe-area handling before changing child objects.
 - For text-heavy UGUI, also inspect `TextMeshProUGUI`, wrapping and overflow behavior, preferred width/height assumptions, and any existing TMP style patterns before resizing containers.
 - For UI Toolkit, find the active `UIDocument`, linked `UXML`, linked `USS`, and panel settings before editing styles.
+- For flex-heavy UI Toolkit screens, inspect container ownership for direction, growth, overflow, and scroll boundaries before changing leaf elements.
 - For text-heavy UI Toolkit, inspect text roles, width rules, overflow behavior, and reusable USS text classes before applying local overrides.
 - If the user provides a layout image and target resolution, treat them as the source spec for composition before creating any objects.
 - If the user provides a layout image but no explicit target resolution, capture the image's native resolution and treat that as the initial reference frame.
@@ -133,6 +135,7 @@ Use screenshots aggressively.
 - Decide whether important text should wrap, truncate, stay single-line, or grow its container before shrinking fonts.
 - Leave reasonable headroom for longer labels, dynamic values, and likely localization growth instead of trusting mockup string lengths literally.
 - For UI Toolkit, prefer USS classes and container rules over many inline style overrides.
+- For UI Toolkit, decide which container owns flex direction, width, overflow, and scroll behavior before patching leaf elements.
 - If the user gives only a visual description, assume one target resolution first, implement for that resolution, then test at additional aspect ratios.
 - If the screen looks crowded, reduce hierarchy complexity and nesting depth before adding more overrides.
 
@@ -167,6 +170,8 @@ Use screenshots aggressively.
 - Read `references/sprite-vs-rawimage.md` when static UI assets are being wired through `RawImage` instead of the normal sprite workflow.
 - Read `references/mockup-safe-area-mapping.md` when a mobile mockup did not visibly account for safe area but the runtime layout must.
 - Read `references/text-layout-rules.md` when text length, wrapping, overflow, auto-size, counters, or localization safety are driving layout instability.
+- Read `references/ui-toolkit-layout-rules.md` when the target is UI Toolkit and you need rules for container ownership, flex behavior, overflow, and text handling.
+- Read `references/ui-toolkit-failures.md` when a UI Toolkit screen renders but still feels fragile, over-patched, or unstable at narrower widths.
 - Read `references/ugui-anchors-canvas-scaler.md` when the target is UGUI or when anchor, pivot, or screen-scaling behavior is causing drift.
 - Read `references/ugui-hud.md` for always-on-screen HUD, minimap, status bars, and action bars.
 - Read `references/ugui-inventory.md` for slot grids, item lists, equipment panels, and shop layouts.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -32,6 +32,11 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `ugui-popup.md`
 - `ugui-mobile-safe-area.md`
 
+## UI Toolkit-Focused Guidance
+
+- `ui-toolkit-layout-rules.md`
+- `ui-toolkit-failures.md`
+
 ## Prompting Guidance
 
 - `prompt-patterns.md`

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -150,6 +150,28 @@ If the request is one-screen or one-flow specific, prefer a variant, wrapper, or
 Only edit the shared asset when the change clearly belongs to the common contract and would make sense across other usages too.
 ```
 
+## Pattern 22: Repair a UI Toolkit Screen Through Container Ownership
+
+Use when the target clearly belongs to UI Toolkit.
+
+```text
+Treat this as a UI Toolkit repair.
+Inspect the current UIDocument, UXML, USS, and visual tree first.
+Identify which containers should own flex direction, width, overflow, and scroll behavior.
+Reduce leaf-level overrides, move repeatable intent into USS classes, and verify the result at the target width and one narrower width.
+```
+
+## Pattern 23: Stabilize UI Toolkit Text and Overflow
+
+Use when UI Toolkit labels, tabs, or body text are breaking the layout.
+
+```text
+Treat text behavior as structural.
+Inspect the parent width rule, white-space or wrapping behavior, overflow handling, and reusable USS text roles first.
+Decide whether important text regions should wrap, truncate, remain single-line, or grow their parent before shrinking fonts.
+Verify the result at a narrower width so the fix is not overfit to one screen size.
+```
+
 ## Pattern 8: Script-Aware UI Editing
 
 Use when script changes are necessary.

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -45,6 +45,7 @@ Ask:
 - Does each repeated group have a clear layout owner?
 - Were repeated structures turned into reusable prefabs or reusable layout blocks where appropriate?
 - Are child offsets being used only for local adjustments rather than structural compensation?
+- If this is UI Toolkit, do containers own flex direction, width, overflow, and scroll behavior instead of leaf overrides?
 
 If many children carry unique offsets, the structure is probably still too fragile.
 
@@ -91,6 +92,7 @@ Ask:
 - Was line behavior chosen deliberately for major text roles instead of left to defaults?
 - Are counters, currencies, and dynamic values given enough room for realistic growth?
 - Did we solve the text issue by fixing layout first instead of immediately shrinking fonts?
+- If this is UI Toolkit, are wrap and overflow behaviors explicit for important text regions instead of being left implicit?
 
 Text problems should be treated as layout problems first, not only font-size problems.
 

--- a/unity-mcp-ui-layout/references/ui-toolkit-failures.md
+++ b/unity-mcp-ui-layout/references/ui-toolkit-failures.md
@@ -1,0 +1,135 @@
+# UI Toolkit Failure Patterns
+
+Use this guide when a UI Toolkit screen technically renders but still feels fragile, inconsistent, or overfit to one width.
+
+This document is symptom-first so it is easier to use during repair work.
+
+## 1. One Inline Fix Breaks Another Region
+
+### Typical symptoms
+
+- changing one element width breaks sibling balance
+- one local margin fix shifts another section unexpectedly
+- a small style tweak improves one screen width but breaks another
+
+### Likely causes
+
+- container ownership is weak
+- too many inline overrides exist
+- the screen layout intent lives in leaves instead of containers
+
+### Fix direction
+
+- move layout ownership back into containers
+- convert repeated overrides into USS classes
+- remove local patches that duplicate container intent
+
+## 2. The Screen Works at One Width but Collapses When Narrower
+
+### Typical symptoms
+
+- side panels collapse too early
+- one column crushes another
+- text suddenly pushes buttons or rows out of shape
+
+### Likely causes
+
+- no explicit min or max width decisions
+- `flex-grow` relationships are implicit or conflicting
+- wrap and overflow behavior were never decided
+
+### Fix direction
+
+- decide which region should compress first
+- add deliberate min or max width rules where needed
+- decide whether text wraps, truncates, or triggers scroll behavior
+
+## 3. Scroll Ownership Is Unclear
+
+### Typical symptoms
+
+- the wrong region scrolls
+- nested scroll containers feel unstable
+- content disappears or clips inside panels
+
+### Likely causes
+
+- multiple nested containers are trying to own overflow
+- screen structure does not define a clear scroll boundary
+- one region is expected to expand and scroll at the same time
+
+### Fix direction
+
+- choose one deliberate scroll owner
+- simplify nested overflow behavior
+- move overflow responsibility higher or lower until the ownership is obvious
+
+## 4. Text Fixes Keep Becoming Font Tweaks
+
+### Typical symptoms
+
+- labels keep shrinking to fit
+- one width works only because text got smaller
+- long labels break buttons, tabs, or inspector rows
+
+### Likely causes
+
+- text role behavior is implicit
+- width ownership is unclear
+- font-size changes are compensating for missing layout decisions
+
+### Fix direction
+
+- decide wrap, truncate, or growth behavior first
+- stabilize parent width and sibling layout first
+- use font changes only after the structure is already reasonable
+
+## 5. The Visual Tree Feels Flat but the Styles Feel Overcomplicated
+
+### Typical symptoms
+
+- too much layout meaning is encoded in classes and local overrides
+- related widgets have no meaningful grouping container
+- debugging the screen requires checking many unrelated elements
+
+### Likely causes
+
+- structure was under-modeled
+- style was asked to do the job of hierarchy
+- grouping containers were skipped too early
+
+### Fix direction
+
+- reintroduce meaningful grouping containers
+- let the tree reveal screen regions clearly
+- keep USS focused on repeatable style, not missing hierarchy
+
+## 6. Reusable UI Toolkit Patterns Still Behave Like One-Off Layouts
+
+### Typical symptoms
+
+- repeated rows still need local patching
+- one panel class almost works but each instance needs exceptions
+- style drift grows across similar screens
+
+### Likely causes
+
+- no stable base class or container pattern exists
+- repeated structure is not actually represented as a reusable pattern
+- the screen evolved through one-off fixes
+
+### Fix direction
+
+- extract a clearer reusable container or class pattern
+- normalize spacing, text role, and alignment rules
+- reduce per-instance exceptions
+
+## 7. Quick Recovery Strategy
+
+When UI Toolkit work starts drifting:
+
+1. inspect the visual tree again
+2. identify the container that should own the failing behavior
+3. reduce leaf-level overrides
+4. make text overflow behavior explicit
+5. verify one narrower width before declaring success

--- a/unity-mcp-ui-layout/references/ui-toolkit-layout-rules.md
+++ b/unity-mcp-ui-layout/references/ui-toolkit-layout-rules.md
@@ -1,0 +1,124 @@
+# UI Toolkit Layout Rules
+
+Use this guide when the task is clearly in Unity UI Toolkit rather than UGUI.
+
+The main rule is simple:
+
+- let containers own layout
+- let classes own repeatable style
+- let text behavior be decided explicitly before emergency overrides
+
+## 1. Start With the Visual Tree
+
+Before changing styles, identify:
+
+- the active `UIDocument`
+- the main screen root
+- the important container layers
+- the `UXML` file that owns structure
+- the `USS` file or files that own repeatable style
+
+Do not begin with scattered inline edits before the container hierarchy is understood.
+
+## 2. Ownership Model
+
+UI Toolkit gets fragile when width, flex, spacing, and alignment ownership are scattered across many leaf nodes.
+
+Use this ownership shape when possible:
+
+```mermaid
+flowchart TD
+    A["ScreenRoot"] --> B["Top-level regions"]
+    B --> C["Feature containers"]
+    C --> D["Leaf controls"]
+```
+
+- `ScreenRoot` owns overall screen flow
+- top-level regions own major layout partitioning
+- feature containers own spacing, grouping, and local flex behavior
+- leaf controls should avoid re-declaring layout intent unless they are truly exceptional
+
+## 3. Prefer Container Rules Over Leaf Overrides
+
+When layout looks wrong, inspect in this order:
+
+1. container direction
+2. flex grow or shrink rules
+3. width and height constraints
+4. alignment and justification
+5. spacing and padding
+6. local overrides on leaf elements
+
+If many leaf elements each carry one-off width, margin, or alignment patches, the layout probably needs container cleanup first.
+
+## 4. Flex-Heavy Screen Rules
+
+For flex-heavy screens such as settings, inventory side panels, dashboards, or editor-style inspectors:
+
+- define which container owns horizontal split
+- define which container owns vertical stacking
+- use explicit min or max width rules where collapse would be harmful
+- keep scroll ownership on one deliberate container
+- avoid mixing too many competing `flex-grow` values without a clear hierarchy
+
+If a screen should survive narrower widths, decide that behavior intentionally instead of trusting default flex resolution.
+
+## 5. Text Behavior Is Structural
+
+For UI Toolkit, text problems often come from leaving width and overflow behavior implicit.
+
+Decide these intentionally:
+
+- should the text wrap?
+- should it truncate?
+- should it keep one line with ellipsis?
+- should the parent grow?
+
+Treat these as structure decisions, not as last-minute visual tweaks.
+
+## 6. Prefer Reusable USS Classes
+
+Use classes for repeatable intent:
+
+- text role
+- row type
+- button family
+- panel family
+- spacing rhythm
+
+Avoid solving repeated problems with many inline overrides.
+
+## 7. Narrow-Width Stability
+
+UI Toolkit screens often look correct at one width and then collapse.
+
+Before calling the layout done, check:
+
+- which container should compress first
+- which region should keep a minimum width
+- where scrolling should begin
+- whether text should wrap before siblings collapse
+
+If none of those decisions were made deliberately, the screen is probably still fragile.
+
+## 8. Anti-Patterns
+
+Avoid these:
+
+- fixing a flex issue with many leaf-level width overrides
+- letting multiple nested containers all fight over scroll behavior
+- scattering one-off margins instead of defining container gap or padding
+- relying on implicit text overflow behavior
+- keeping repeatable UI style only in inline rules instead of USS classes
+
+## 9. Review Questions
+
+Ask:
+
+- Does each important UI Toolkit region have a clear container owner?
+- Are flex, width, and spacing decisions concentrated in containers instead of leaves?
+- Are text wrap and overflow behaviors explicit for important regions?
+- Would a narrower width still produce an intentional result?
+- Are reusable USS classes doing the heavy lifting where appropriate?
+
+If the answer is no, the screen likely needs structural cleanup before more styling work.


### PR DESCRIPTION
## 요약\n- UI Toolkit 전용 레이아웃 가이드 추가\n- UI Toolkit 전용 실패 패턴 추가\n- UI Toolkit 실전 예시 추가\n\n## 상세\n- ui-toolkit-layout-rules.md를 추가해 container ownership, flex 안정성, overflow, text handling 규칙을 정리했습니다.\n- ui-toolkit-failures.md를 추가해 UI Toolkit 화면이 한 폭에서만 맞거나 inline override에 과도하게 의존하는 문제를 symptom-first로 정리했습니다.\n- ui-toolkit-example.md를 추가해 실제로 복사해서 쓸 수 있는 UI Toolkit 프롬프트 예시를 넣었습니다.\n- SKILL.md, eferences/README.md, prompt-patterns.md, eview-checks.md, examples/README.md, README.md에 연결을 반영했습니다.\n\n## 검증\n- 로컬 스킬 검증 통과\n- 전역 스킬 동기화 및 검증 통과\n\nCloses #24