### PR TITLE
공유 자산 검증 레시피 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Platform-specific adapters live in:
 - text layout rules for wrapping, truncation, auto-size discipline, counters, and localization headroom
 - safe-area remapping rules for mobile mockups that do not visibly account for notches or home indicators
 - shared asset edit safety rules for deciding when direct base edits are too risky
+- shared asset verification recipes for checking another known usage before direct base edits
 - UI Toolkit container ownership, flex stability, and text overflow guidance
 - concrete MCP call recipes for common UI tasks
 - common failure patterns and recovery guidance
@@ -81,6 +82,7 @@ Platform-specific adapters live in:
 - 줄바꿈, truncation, auto-size 절제, 숫자 영역, 지역화 여유를 위한 텍스트 레이아웃 규칙
 - 노치/홈 인디케이터가 없는 시안을 모바일 safe area 안쪽 여백으로 재해석하는 규칙
 - 공용 prefab/sprite/material/text style에 대한 직접 수정이 위험한지 판단하는 안전 규칙
+- 공용 자산 직접 수정 전에 다른 known usage를 확인하는 shared asset verification 레시피
 - UI Toolkit 화면에서 container ownership, flex 안정성, text overflow를 다루는 가이드
 - 자주 쓰는 UI 작업용 구체적인 MCP 호출 레시피
 - 자주 실패하는 패턴과 복구 가이드

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - `mobile-safe-area-mockup-example.md`
 - `popup-safe-area-example.md`
 - `shared-asset-safety-example.md`
+- `shared-asset-verification-example.md`
 - `ui-toolkit-example.md`
 
 ## How to Use
@@ -36,4 +37,5 @@ Use these files when you want a copyable starting point instead of only referenc
 4. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
 5. `popup-safe-area-example.md` if mobile safe area and modal structure matter
 6. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
-7. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`
+7. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
+8. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/shared-asset-verification-example.md
+++ b/examples/shared-asset-verification-example.md
@@ -1,0 +1,24 @@
+# Shared Asset Verification Example
+
+Use this example when a one-screen repair might accidentally mutate a shared base asset.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to repair this screen, but verify shared asset impact before changing anything common.
+If the affected widget comes from a shared prefab, sprite, material, or TMP style family, find one additional known usage first.
+Compare whether the requested change truly belongs to the shared contract or should stay local through a variant, wrapper, duplicated asset, or local override.
+Do not edit the shared base directly until that comparison is explicit.
+```
+
+## Why This Works
+
+- It forces impact review before direct base edits.
+- It keeps one-screen rescue work from quietly becoming a project-wide regression.
+- It gives the agent a concrete decision gate instead of a vague warning.
+
+## Suggested References
+
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\shared-asset-edit-safety.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\shared-asset-verification-recipes.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\prefab-variants.md`

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -167,6 +167,7 @@ Use screenshots aggressively.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.
 - Read `references/review-checks.md` when you need a final quality pass before calling a Unity UI task complete.
 - Read `references/shared-asset-edit-safety.md` when a one-screen request might tempt you to edit a shared prefab, sprite, material, or text style directly.
+- Read `references/shared-asset-verification-recipes.md` when you need concrete shared-asset verification flow before directly editing a common prefab, sprite, material, or TMP style.
 - Read `references/sprite-vs-rawimage.md` when static UI assets are being wired through `RawImage` instead of the normal sprite workflow.
 - Read `references/mockup-safe-area-mapping.md` when a mobile mockup did not visibly account for safe area but the runtime layout must.
 - Read `references/text-layout-rules.md` when text length, wrapping, overflow, auto-size, counters, or localization safety are driving layout instability.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -16,6 +16,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `asset-naming-and-folders.md`
 - `existing-prefab-reuse.md`
 - `shared-asset-edit-safety.md`
+- `shared-asset-verification-recipes.md`
 - `prefab-variants.md`
 - `prefab-reuse.md`
 - `mockup-safe-area-mapping.md`

--- a/unity-mcp-ui-layout/references/mcp-call-recipes.md
+++ b/unity-mcp-ui-layout/references/mcp-call-recipes.md
@@ -279,3 +279,69 @@ Verify the target variant and one related base-family usage with screenshots.
 - `manage_components`
 - `manage_camera`
 - `read_console`
+
+## 11. Verify Another Known Usage Before Editing a Shared Prefab
+
+Use this when a requested repair might tempt you to edit a shared prefab directly.
+
+### Typical sequence
+
+1. Identify the current target instance and likely shared prefab family
+2. Find one additional known usage of that family
+3. Compare whether the requested change belongs to the shared base or is only local
+4. Choose direct edit, variant, wrapper, or local override
+5. Verify the target and the additional known usage if a direct base edit is still chosen
+
+### Example prompt
+
+```text
+Before editing this shared prefab directly, inspect the target instance and one additional known usage of the same prefab family.
+Compare whether the requested change belongs to the shared base contract or should stay local through a variant, wrapper, or override.
+Only perform a direct base edit if the comparison shows the change is truly shared.
+```
+
+### Common calls
+
+- `find_gameobjects`
+- `manage_prefabs`
+- `manage_gameobject`
+- `manage_components`
+- `manage_camera`
+
+## 12. Verify a Shared Sprite or Material Before Mutating It
+
+Use this when a local repair might otherwise alter a common visual asset directly.
+
+### Typical sequence
+
+1. Confirm whether the sprite or material is common rather than screen-owned
+2. Find one additional usage that relies on the same asset
+3. Compare whether the requested visual change still makes sense there
+4. If not, duplicate or localize the asset instead of mutating the shared one
+
+### Example prompt
+
+```text
+Inspect whether this sprite or material is shared before editing it.
+Find one additional usage of the same asset and compare whether the requested visual change belongs to the shared contract or only to this screen.
+If it is local, keep the change in a duplicated or screen-owned asset instead of mutating the shared one.
+```
+
+## 13. Verify a Shared TMP Style Before Using It as a Rescue Fix
+
+Use this when a crowded row or overflow issue might tempt you to rewrite a shared text style.
+
+### Typical sequence
+
+1. Confirm whether the current text presentation comes from a shared style family
+2. Inspect one other usage of the same style role
+3. Decide whether the requested size, spacing, or overflow change is truly shared
+4. If not, keep the rescue local through a local style or new named style
+
+### Example prompt
+
+```text
+Inspect whether this TMP style is shared before changing it.
+Find one other usage of the same style role and compare whether the requested text adjustment should really apply there too.
+If it is only a local rescue change, keep it out of the shared text style.
+```

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -172,6 +172,36 @@ Decide whether important text regions should wrap, truncate, remain single-line,
 Verify the result at a narrower width so the fix is not overfit to one screen size.
 ```
 
+## Pattern 24: Verify Another Known Usage Before Shared Base Edit
+
+Use when a requested fix might touch a shared prefab, sprite, material, or TMP style directly.
+
+```text
+Before editing the shared asset directly, inspect one additional known usage of the same asset family.
+Compare whether the requested change really belongs to the shared contract or should stay local through a variant, wrapper, duplicated asset, or local override.
+Do not edit the shared base until that comparison is explicit.
+```
+
+## Pattern 25: Verify a Shared Sprite or Material First
+
+Use when a local visual repair might otherwise mutate a common sprite or material.
+
+```text
+Inspect whether this sprite or material is shared before changing it.
+Find one additional usage of the same asset and compare whether the requested visual adjustment should really apply there too.
+If the change is local, keep it in a duplicated or screen-owned asset instead of mutating the shared one.
+```
+
+## Pattern 26: Verify a Shared TMP Style First
+
+Use when a text rescue might otherwise rewrite a common text style.
+
+```text
+Inspect whether the current TMP style is shared before changing it.
+Find one additional usage of the same style role and compare whether the requested text adjustment belongs to the shared role or only to this screen.
+If it is only a local rescue, keep it out of the shared style.
+```
+
 ## Pattern 8: Script-Aware UI Editing
 
 Use when script changes are necessary.

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -136,6 +136,7 @@ Ask:
 - Was the original style preserved when the request was a repair?
 - Did we stay in the correct operating mode: bounded repair for fixes, or build mode for true greenfield work?
 - If an existing shared asset was edited directly, was that scope truly justified?
+- If a shared asset was edited directly, was at least one additional known usage checked first where practical?
 
 If the answer is no, narrow the change before shipping it.
 

--- a/unity-mcp-ui-layout/references/shared-asset-verification-recipes.md
+++ b/unity-mcp-ui-layout/references/shared-asset-verification-recipes.md
@@ -1,0 +1,110 @@
+# Shared Asset Verification Recipes
+
+Use this guide when a requested UI change might touch a shared prefab, sprite, material, or TMP style and you need a practical review flow before editing the shared base directly.
+
+These recipes are intentionally conservative.
+The point is to stop one-screen fixes from quietly becoming shared regressions.
+
+## 1. Shared Prefab Verification
+
+Use this when the target widget may belong to a shared prefab family.
+
+### Typical sequence
+
+1. Inspect the current screen instance and identify the likely prefab family
+2. Decide whether the requested change is truly shared or still local
+3. Find at least one additional known usage of the same family
+4. Compare whether the requested change would still make sense there
+5. Only then decide between direct base edit, variant, wrapper, or local override
+
+### Example prompt
+
+```text
+Before editing this shared prefab directly, inspect the current screen instance and identify one additional known usage of the same prefab family.
+Compare whether the requested change belongs to the shared base contract or should stay local through a variant, wrapper, or override.
+Do not edit the shared base until that comparison is explicit.
+```
+
+### Common calls
+
+- `find_gameobjects`
+- `manage_prefabs`
+- `manage_gameobject`
+- `manage_components`
+- `manage_camera`
+
+## 2. Shared Sprite Verification
+
+Use this when a screen seems to rely on a common sprite or atlas-backed visual.
+
+### Typical sequence
+
+1. Confirm that the sprite is truly shared and not screen-owned
+2. Inspect one other usage where the same sprite appears
+3. Decide whether the requested visual change belongs to the shared art contract
+4. If not, use a screen-owned sprite, placeholder replacement path, or different asset instead of mutating the shared one
+
+### Example prompt
+
+```text
+Inspect whether this sprite is shared across more than one screen before changing it.
+Find one other usage of the same sprite or sprite-backed visual and compare whether the requested change should really apply there too.
+If not, keep the change local instead of mutating the shared sprite asset.
+```
+
+## 3. Shared Material Verification
+
+Use this when a requested effect might be applied by changing a common UI material.
+
+### Typical sequence
+
+1. Confirm that the material is common rather than screen-owned
+2. Inspect another usage that depends on the same material
+3. Decide whether the requested visual effect is part of the common treatment or only local to the target screen
+4. If local, duplicate or localize the material instead of editing the shared one
+
+### Example prompt
+
+```text
+Inspect whether this UI material is shared by other screens before editing it.
+Find at least one additional usage and compare whether the requested effect belongs to the shared visual contract or only to this screen.
+If it is local, use a duplicated or screen-owned material instead of mutating the shared one.
+```
+
+## 4. Shared TMP Style Verification
+
+Use this when a text layout fix might tempt you to change a shared TMP style or shared text presentation rule.
+
+### Typical sequence
+
+1. Confirm that the current text styling comes from a shared style family
+2. Inspect one other usage of the same style role
+3. Decide whether the requested change is a true role improvement or a local rescue tweak
+4. If it is local, use a local style, local override, or new named style instead of rewriting the common one
+
+### Example prompt
+
+```text
+Inspect whether this text style is shared before changing it.
+Find one other usage of the same style role and compare whether the requested size, spacing, or overflow change should really apply there too.
+If it is only a local rescue tweak, keep it out of the shared text style.
+```
+
+## 5. Minimum Safe Review Rule
+
+If you cannot inspect another known usage:
+
+- treat direct shared-base editing as higher risk
+- bias toward variant, wrapper, local override, or duplicated asset
+- only proceed with direct edit if the change is obviously global and low-risk
+
+## 6. Review Questions
+
+Ask:
+
+- Did we confirm the asset is truly shared?
+- Did we inspect at least one additional known usage before editing the shared base directly?
+- Did the requested change still make sense in that additional usage?
+- If we could not verify another usage, did we bias toward a safer local path?
+
+If the answer is no, direct shared-base editing is probably still under-verified.


### PR DESCRIPTION
## 요약\n- shared asset verification 레시피 문서 추가\n- shared prefab / sprite / material / TMP style 검증 흐름 보강\n- 관련 예시와 프롬프트 패턴 추가\n\n## 상세\n- shared-asset-verification-recipes.md를 추가해 direct base edit 전에 다른 known usage를 확인하는 실전 흐름을 정리했습니다.\n- mcp-call-recipes.md에 shared prefab, sprite/material, TMP style 검증 레시피를 추가했습니다.\n- prompt-patterns.md에 shared asset verification용 패턴을 추가했습니다.\n- shared-asset-verification-example.md를 추가해 복사해서 쓸 수 있는 예시를 넣었습니다.\n- SKILL.md, eferences/README.md, eview-checks.md, examples/README.md, README.md에 연결을 반영했습니다.\n\n## 검증\n- 로컬 스킬 검증 통과\n- 전역 스킬 동기화 및 검증 통과\n\nCloses #26