### PR TITLE
자산 네이밍/폴더 실전 예시 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Platform-specific adapters live in:
 - repair mode vs greenfield build mode rules for existing-screen fixes versus new UI creation
 - asset discovery priority rules for prefab, sprite, font, material, and placeholder reuse order
 - asset naming and folder rules so reusable assets stay discoverable and screen-owned assets stay scoped correctly
+- practical naming and folder examples for shared versus screen-owned assets and variant family organization
 - text layout rules for wrapping, truncation, auto-size discipline, counters, and localization headroom
 - safe-area remapping rules for mobile mockups that do not visibly account for notches or home indicators
 - shared asset edit safety rules for deciding when direct base edits are too risky
@@ -79,6 +80,7 @@ Platform-specific adapters live in:
 - 기존 UI 수정 요청과 신규 UI 생성 요청을 구분하는 작업 모드 규칙
 - 프리팹, 스프라이트, 폰트, 머티리얼, 플레이스홀더를 어떤 순서로 찾을지에 대한 자산 탐색 우선순위 규칙
 - 재사용 자산은 다시 찾기 쉽고 화면 전용 자산은 범위가 드러나도록 만드는 자산 네이밍/폴더 규칙
+- shared vs screen-owned 자산과 variant family 구성을 실제 트리로 보여주는 실전 예시
 - 줄바꿈, truncation, auto-size 절제, 숫자 영역, 지역화 여유를 위한 텍스트 레이아웃 규칙
 - 노치/홈 인디케이터가 없는 시안을 모바일 safe area 안쪽 여백으로 재해석하는 규칙
 - 공용 prefab/sprite/material/text style에 대한 직접 수정이 위험한지 판단하는 안전 규칙

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - `mockup-resolution-example.md`
 - `mobile-safe-area-mockup-example.md`
 - `popup-safe-area-example.md`
+- `asset-naming-example.md`
 - `shared-asset-safety-example.md`
 - `shared-asset-verification-example.md`
 - `ui-toolkit-example.md`
@@ -36,6 +37,7 @@ Use these files when you want a copyable starting point instead of only referenc
 3. `mockup-resolution-example.md` if the mockup's native pixel resolution should drive planning
 4. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
 5. `popup-safe-area-example.md` if mobile safe area and modal structure matter
-6. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
-7. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
-8. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`
+6. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
+7. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
+8. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
+9. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/asset-naming-example.md
+++ b/examples/asset-naming-example.md
@@ -1,0 +1,24 @@
+# Asset Naming Example
+
+Use this example when the task is not only to build UI, but also to normalize asset names and folder placement so future reuse is easier.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to normalize the naming and folder placement of the UI assets touched by this change.
+Decide which assets are truly shared and which are screen-owned.
+Move shared assets into stable common UI folders, keep screen-owned assets near the screen that owns them, and keep placeholders visibly provisional.
+Rename assets by role and scope instead of copy-history, coordinates, or temporary labels.
+If a prefab family has real variants, group them near the base prefab in a clear Variants folder.
+```
+
+## Why This Works
+
+- It forces a scope decision before renaming or moving assets.
+- It discourages accidental promotion into `Common`.
+- It gives the agent a stable target structure for future discovery.
+
+## Suggested References
+
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\asset-naming-and-folders.md`
+- `D:\UnityUICreater\unity-mcp-ui-layout\references\asset-naming-examples.md`

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -162,6 +162,7 @@ Use screenshots aggressively.
 - Read `references/ui-change-modes.md` when you need to decide whether the task should be handled as bounded repair or as a new build.
 - Read `references/asset-discovery-priority.md` when asset-aware mode is active and you need to decide what kinds of existing assets to search in what order.
 - Read `references/asset-naming-and-folders.md` when asset-aware mode is creating, extracting, or reorganizing UI assets and you need stable naming plus shared-versus-screen folder rules.
+- Read `references/asset-naming-examples.md` when you want concrete before/after folder trees, naming comparisons, and variant folder examples for shared versus screen-owned assets.
 - Read `references/existing-prefab-reuse.md` when the project likely already contains a similar reusable UI block and you need to choose reuse, variant, wrapper, or a new base prefab.
 - Read `references/prefab-variants.md` when one shared base prefab should branch into a controlled family of variants without polluting the base asset.
 - Read `references/prefab-reuse.md` when the same UI shape appears more than once and should be extracted into one reusable prefab or template-style block.

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -14,6 +14,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `ui-change-modes.md`
 - `asset-discovery-priority.md`
 - `asset-naming-and-folders.md`
+- `asset-naming-examples.md`
 - `existing-prefab-reuse.md`
 - `shared-asset-edit-safety.md`
 - `shared-asset-verification-recipes.md`

--- a/unity-mcp-ui-layout/references/asset-naming-and-folders.md
+++ b/unity-mcp-ui-layout/references/asset-naming-and-folders.md
@@ -4,6 +4,8 @@ Use this guide when asset-aware mode creates, promotes, or reorganizes UI assets
 
 The goal is simple: if an agent creates or extracts a useful asset today, another agent should be able to find and reuse it later without guessing.
 
+If you need concrete before/after trees and variant folder examples, pair this guide with `asset-naming-examples.md`.
+
 ## 1. Core Naming Principles
 
 - Prefer short names that reveal role immediately.

--- a/unity-mcp-ui-layout/references/asset-naming-examples.md
+++ b/unity-mcp-ui-layout/references/asset-naming-examples.md
@@ -1,0 +1,156 @@
+# Asset Naming and Folder Examples
+
+Use this guide together with `asset-naming-and-folders.md` when you want concrete before/after examples instead of only abstract rules.
+
+## 1. Shared vs Screen-Owned Before/After
+
+### Bad
+
+The structure below makes reuse hard to reason about:
+
+```text
+Assets/UI/Inventory/
+  Button_New.prefab
+  CommonButton_Copy.prefab
+  GoldIcon.png
+  PopupBlur.mat
+```
+
+Problems:
+
+- a likely shared button is buried inside one screen folder
+- the names do not reveal scope clearly
+- one asset looks copied rather than intentionally promoted
+- a common visual treatment appears screen-owned by accident
+
+### Better
+
+```text
+Assets/UI/Common/Prefabs/Buttons/
+  UI_Common_Button_Primary.prefab
+
+Assets/UI/Common/Sprites/Icons/
+  UI_Common_Icon_Gold.sprite
+
+Assets/UI/Common/Materials/
+  UI_Common_BlurOverlay.mat
+
+Assets/UI/Screens/Inventory/Prefabs/
+  UI_Inventory_ActionBar.prefab
+```
+
+Why this is better:
+
+- shared assets read as shared
+- screen-owned assets stay near the screen that owns them
+- names reveal role and scope immediately
+
+## 2. Bad Names vs Better Names
+
+| Bad | Better | Why |
+|---|---|---|
+| `Button_New` | `UI_Common_Button_Primary` | role and scope are explicit |
+| `InventorySlot_Copy` | `UI_Inventory_Slot` | no copy-history noise |
+| `TopLeft_1920_Button` | `UI_HUD_QuickSlotButton` | meaning instead of coordinates |
+| `Popup_v3_really_final` | `UI_Settings_PopupRoot` | stable ownership and role |
+| `GoldIcon2` | `UI_Common_Icon_Gold` | reusable naming family |
+
+## 3. Variant Folder Example
+
+Use a structure like this when one shared base prefab has a real family of variants:
+
+```text
+Assets/UI/Common/Prefabs/Buttons/
+  UI_Common_Button_Primary.prefab
+  Variants/
+    UI_Common_Button_Primary_Selected.prefab
+    UI_Common_Button_Primary_Disabled.prefab
+    UI_Common_Button_Primary_Danger.prefab
+```
+
+This works well when:
+
+- the base contract is stable
+- variants differ in controlled local ways
+- the family is large enough to justify a `Variants` folder
+
+## 4. Wrapper vs Variant Example
+
+### Variant case
+
+```text
+Assets/UI/Common/Prefabs/RewardCard/
+  UI_Common_RewardCard.prefab
+  Variants/
+    UI_Common_RewardCard_Epic.prefab
+```
+
+Use this when the base card structure is right and only scoped visuals or optional sections differ.
+
+### Wrapper case
+
+```text
+Assets/UI/Common/Prefabs/RewardCard/
+  UI_Common_RewardCard.prefab
+
+Assets/UI/Screens/Inventory/Prefabs/
+  UI_Inventory_RewardCardHost.prefab
+```
+
+Use this when the screen needs extra surrounding layout or screen-owned composition that should not pollute the shared base.
+
+## 5. Placeholder Example
+
+### Bad
+
+```text
+Assets/UI/Common/Sprites/
+  GoldIconTemp.png
+```
+
+This quietly makes a placeholder look like a permanent shared asset.
+
+### Better
+
+```text
+Assets/UI/Screens/Inventory/Placeholders/
+  UI_Inventory_Placeholder_ItemIcon.sprite
+```
+
+This keeps provisional work visibly provisional and easy to replace later.
+
+## 6. Promotion Example
+
+A repeated screen-owned block can start local and later be promoted.
+
+### Early stage
+
+```text
+Assets/UI/Screens/Inventory/Prefabs/
+  UI_Inventory_ItemCard.prefab
+```
+
+### After real reuse becomes visible
+
+```text
+Assets/UI/Common/Prefabs/ItemCard/
+  UI_Common_ItemCard.prefab
+  Variants/
+    UI_Common_ItemCard_Selected.prefab
+```
+
+The important point is:
+
+- do not promote too early
+- but once a pattern is clearly shared, rename and relocate it deliberately
+
+## 7. Review Questions
+
+Ask:
+
+- If a new teammate opened this folder tree, would they know what is shared?
+- If a variant exists, is it grouped clearly with its base family?
+- If the asset is still local to one screen, does the path reveal that?
+- Are placeholders visibly provisional instead of looking like final design-system assets?
+
+If the answer is no, clean up naming and placement before the pattern spreads.

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -252,6 +252,17 @@ Keep shared assets in predictable shared UI folders, keep screen-owned assets ne
 Do not leave reusable assets with clone, copy, temp, or coordinate-based names.
 ```
 
+## Pattern 9D: Normalize Shared vs Screen-Owned Asset Placement
+
+Use when asset-aware work also needs naming and folder cleanup.
+
+```text
+Normalize the names and folder placement of the UI assets touched by this change.
+Decide which assets are truly shared and which are still screen-owned.
+Move shared assets into stable common UI folders, keep screen-owned assets near the screen that owns them, group real variant families near their base prefab, and keep placeholders visibly provisional.
+Do not keep copy-history or coordinate-based names.
+```
+
 ## Pattern 10: UGUI HUD Build
 
 Use when building or repairing a HUD.


### PR DESCRIPTION
## 요약\n- asset naming 실전 예시 문서 추가\n- shared vs screen-owned before/after 예시 추가\n- variant 폴더 구성 예시 추가\n\n## 상세\n- sset-naming-examples.md를 추가해 shared vs screen-owned 자산의 before/after 폴더 트리, bad vs better 이름 비교, variant folder 예시, placeholder 예시, promotion 예시를 넣었습니다.\n- sset-naming-example.md를 추가해 복사해서 쓸 수 있는 예시 프롬프트를 넣었습니다.\n- sset-naming-and-folders.md, SKILL.md, eferences/README.md, prompt-patterns.md, examples/README.md, README.md에 연결을 반영했습니다.\n\n## 검증\n- 로컬 스킬 검증 통과\n- 전역 스킬 동기화 및 검증 통과\n\nCloses #25