### PR TITLE
[codex] Add repair asset-aware reuse example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - `popup-safe-area-example.md`
 - `scroll-view-example.md`
 - `repair-one-region-example.md`
+- `repair-asset-aware-reuse-example.md`
 - `asset-naming-example.md`
 - `localized-screen-example.md`
 - `long-labels-and-counters-example.md`
@@ -44,6 +45,17 @@ Use these files when you want a copyable starting point instead of only referenc
 - Start with `ui-toolkit-example.md` when the target is clearly driven by `UIDocument`, `UXML`, and `USS`.
 - If the stack is not obvious yet, decide that first before choosing a task-shaped example.
 
+## Pick by Problem
+
+- Start with `first-layout-pass-example.md` when you need a small build-mode exercise before choosing a domain-shaped example.
+- Start with `current-vs-mockup-example.md` when the existing screen should be compared against a reference before repair.
+- Start with `repair-one-region-example.md` when the request must stay bounded to one named region.
+- Start with `repair-asset-aware-reuse-example.md` when the repair may touch reusable prefabs, variants, wrappers, shared sprites, materials, or text styles.
+- Start with `shared-asset-verification-example.md` when a direct shared-base edit might be needed but another usage should be checked first.
+- Start with `asset-naming-example.md` when the task creates, promotes, or normalizes reusable UI assets.
+- Start with `localized-screen-example.md` or `long-labels-and-counters-example.md` when text growth is the main layout risk.
+- Start with `mobile-safe-area-mockup-example.md` when a mobile mockup ignores notch or home-indicator constraints.
+
 ## Suggested Reading Order
 
 1. `first-layout-pass-example.md` if you want the smallest structure-first practice task
@@ -55,9 +67,10 @@ Use these files when you want a copyable starting point instead of only referenc
 7. `popup-safe-area-example.md` if mobile safe area and modal structure matter
 8. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
 9. `repair-one-region-example.md` if the request should stay bounded to one named region
-10. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
-11. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
-12. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
-13. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
-14. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
-15. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`
+10. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
+11. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
+12. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
+13. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
+14. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
+15. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
+16. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/repair-asset-aware-reuse-example.md
+++ b/examples/repair-asset-aware-reuse-example.md
@@ -1,0 +1,58 @@
+# Repair With Asset-Aware Reuse Example
+
+Use this example when an existing screen needs a bounded repair, but the affected widget might belong to a reusable prefab, variant family, shared sprite, material, or text style.
+
+## Scenario
+
+The current UI mostly works, but one repeated or shared-looking block is misaligned, visually outdated, or missing a local state. The goal is not to rebuild the screen. The goal is to repair the target area while making an explicit reuse decision: direct reuse, prefab variant, wrapper, local override, or new base prefab.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to repair the [target region or widget] in asset-aware mode.
+Keep this in repair mode unless inspection proves the existing structure is not worth preserving.
+Inspect the current screen, parent chain, and similar reusable UI candidates before creating new assets or placeholders.
+
+Follow this reuse decision order:
+1. Reuse an existing stable prefab or UI block directly if only data, text, icon, count, or state values need to change.
+2. Create a prefab variant or thin wrapper if the base structure is right but this screen needs scoped visuals, optional sections, or local behavior.
+3. Create a new base prefab only if existing candidates are structurally misleading, too coupled, or unsafe to extend.
+
+Keep screen-level placement in the parent container instead of pushing one-screen anchors, offsets, or layout ownership into a shared base prefab.
+If a variant would need many structural overrides, stop and reconsider a wrapper or new base prefab.
+If a direct shared-base edit still looks necessary, find one additional known usage first and compare whether the requested change should apply there too.
+If that impact cannot be verified, prefer a variant, wrapper, local override, or screen-owned asset.
+Do not mutate shared sprites, materials, or TMP styles for a one-screen visual or text fix unless the change is truly global.
+Name any new or promoted assets by role and scope, and keep placeholders visibly provisional.
+Verify the repaired target screen and one related base-family usage before finalizing.
+```
+
+## Why This Works
+
+- It keeps a repair request from quietly becoming a broad rebuild.
+- It forces reusable asset discovery before placeholder-driven reconstruction.
+- It separates data-level reuse from variant-worthy scoped differences.
+- It prevents one-screen anchors or spacing fixes from leaking into shared prefab bases.
+- It gives direct shared-base edits a concrete verification gate.
+- It keeps shared sprites, materials, and text styles out of local rescue fixes.
+
+## Decision Checklist
+
+- Did the task stay in repair mode unless a rebuild was justified?
+- Were existing prefab or reusable UI candidates inspected before creating anything new?
+- Is the chosen path explicit: direct reuse, variant, wrapper, local override, or new base?
+- If a variant was considered, did the base structure still fit without heavy structural overrides?
+- Are screen-level placement rules kept outside shared prefab assets?
+- Was another known usage checked before any direct shared-base edit?
+- Were shared sprites, materials, and TMP styles left alone unless the change was truly global?
+- Are new or promoted assets named by role and scope rather than copy history or temporary labels?
+
+## Suggested References
+
+- [ui-change-modes.md](../unity-mcp-ui-layout/references/ui-change-modes.md)
+- [existing-prefab-reuse.md](../unity-mcp-ui-layout/references/existing-prefab-reuse.md)
+- [prefab-variants.md](../unity-mcp-ui-layout/references/prefab-variants.md)
+- [shared-asset-edit-safety.md](../unity-mcp-ui-layout/references/shared-asset-edit-safety.md)
+- [shared-asset-verification-recipes.md](../unity-mcp-ui-layout/references/shared-asset-verification-recipes.md)
+- [asset-naming-and-folders.md](../unity-mcp-ui-layout/references/asset-naming-and-folders.md)
+- [prompt-patterns.md](../unity-mcp-ui-layout/references/prompt-patterns.md)


### PR DESCRIPTION
## Summary
- Add a repair-focused asset-aware reuse example for prefab reuse, variants, wrappers, and shared asset impact checks.
- Add a problem-first picker to the examples index so users can find repair, shared-asset, naming, text-growth, and mobile-safe-area examples faster.

## Why
This implements the first slice of #40 by filling the biggest gap between the reference docs and copyable examples. The new example ties together repair mode, existing prefab reuse, prefab variants, shared asset safety, and shared usage verification.

## Validation
- git diff --check
- git diff --cached --check
- git diff --check HEAD~1..HEAD
- Verified all linked reference files exist with shell file checks
- rg -n "repair-asset-aware-reuse-example|Repair With Asset-Aware Reuse|Pick by Problem|direct reuse|variant|wrapper|shared-base|TMP styles" examples/README.md examples/repair-asset-aware-reuse-example.md

Refs #40