### PR TITLE
[codex] Add settings dialog example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - `mobile-safe-area-mockup-example.md`
 - `current-vs-mockup-example.md`
 - `popup-safe-area-example.md`
+- `settings-dialog-example.md`
 - `scroll-view-example.md`
 - `repair-one-region-example.md`
 - `repair-asset-aware-reuse-example.md`
@@ -40,9 +41,9 @@ Use these files when you want a copyable starting point instead of only referenc
 ## Pick by Stack
 
 - Start with `first-layout-pass-example.md` if you are new to the workflow or want one small structure-first practice task before choosing a domain-shaped example.
-- Start with `hud-example.md`, `inventory-example.md`, `popup-safe-area-example.md`, or `mobile-safe-area-mockup-example.md` when the target is clearly UGUI.
+- Start with `hud-example.md`, `inventory-example.md`, `popup-safe-area-example.md`, `settings-dialog-example.md`, or `mobile-safe-area-mockup-example.md` when the target is clearly UGUI.
 - Start with `scroll-view-example.md` when the main problem is list/feed/catalog scrolling plus repeated item reuse.
-- Start with `ui-toolkit-example.md` when the target is clearly driven by `UIDocument`, `UXML`, and `USS`.
+- Start with `ui-toolkit-example.md` or `settings-dialog-example.md` when the target is clearly driven by `UIDocument`, `UXML`, and `USS`.
 - If the stack is not obvious yet, decide that first before choosing a task-shaped example.
 
 ## Pick by Problem
@@ -54,6 +55,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - Start with `shared-asset-verification-example.md` when a direct shared-base edit might be needed but another usage should be checked first.
 - Start with `asset-naming-example.md` when the task creates, promotes, or normalizes reusable UI assets.
 - Start with `localized-screen-example.md` or `long-labels-and-counters-example.md` when text growth is the main layout risk.
+- Start with `settings-dialog-example.md` when the screen is a dense options, preferences, pause-menu settings, or configuration dialog.
 - Start with `mobile-safe-area-mockup-example.md` when a mobile mockup ignores notch or home-indicator constraints.
 
 ## Suggested Reading Order
@@ -65,12 +67,13 @@ Use these files when you want a copyable starting point instead of only referenc
 5. `current-vs-mockup-example.md` if the screen already exists and should be compared against a reference image first
 6. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
 7. `popup-safe-area-example.md` if mobile safe area and modal structure matter
-8. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
-9. `repair-one-region-example.md` if the request should stay bounded to one named region
-10. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
-11. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
-12. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
-13. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
-14. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
-15. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
-16. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`
+8. `settings-dialog-example.md` if the screen is a dense options or preferences dialog
+9. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
+10. `repair-one-region-example.md` if the request should stay bounded to one named region
+11. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
+12. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
+13. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
+14. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
+15. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
+16. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
+17. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/settings-dialog-example.md
+++ b/examples/settings-dialog-example.md
@@ -1,0 +1,52 @@
+# Settings Dialog Example
+
+Use this example when the target is a settings, preferences, options, pause-menu settings, or configuration dialog with grouped controls such as toggles, dropdowns, sliders, segmented choices, and apply/cancel actions.
+
+## Scenario
+
+The user wants a settings dialog that stays readable as labels grow, keeps dense controls aligned, and does not let the footer actions drift or scroll accidentally. The goal is to define the dialog shell, section groups, control rows, and verification behavior before polishing individual widgets.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to build or repair this settings dialog.
+Identify the active UI stack first and do not mix UGUI and UI Toolkit in the same change unless I explicitly ask for a bridge.
+If this is UGUI, structure it as `Canvas -> ModalLayer`, with `Dimmer` and `PopupRoot` as siblings, and keep title, scrollable settings body, and footer actions inside `PopupRoot`.
+If this is UI Toolkit, inspect the active UIDocument, UXML, USS, and visual tree first, then keep layout ownership in containers and repeatable styling in USS classes.
+
+Group the dialog into title/header, settings body, and footer action regions before tuning individual controls.
+Inside the settings body, group controls by section and make one reusable row pattern for label + control + optional description or value text.
+Keep the settings body as the only scroll owner when the content is long; title, close button, and apply/cancel actions should stay outside the scrolling content.
+For toggles, dropdowns, sliders, and segmented choices, align labels and controls through parent row rules instead of per-widget offsets.
+Decide whether each important label should wrap, truncate, or reserve fixed width before changing font sizes.
+Verify the dialog at the main target size and one narrower or denser text scenario, including longer labels and realistic option values.
+If this is mobile settings UI, also verify portrait and landscape when safe-area pressure matters.
+```
+
+## Why This Works
+
+- It makes the stack decision explicit before layout work starts.
+- It treats a settings dialog as a shell plus repeated control rows, not as many unrelated widgets.
+- It keeps footer actions fixed while only the settings body scrolls.
+- It pushes label, value, and control alignment into parent row rules.
+- It verifies long labels and dense controls before visual polish.
+
+## Decision Checklist
+
+- Is the UI stack clear: UGUI or UI Toolkit?
+- Does the dialog have distinct header, body, and footer ownership?
+- Is there exactly one intended scroll owner for long settings content?
+- Are repeated control rows reusable instead of hand-positioned one by one?
+- Are labels and values given explicit wrap, truncate, or width rules?
+- Do apply/cancel actions remain reachable when the settings body scrolls?
+- Was the dialog checked with longer labels or realistic option values?
+- If this is mobile settings UI, was portrait and landscape behavior checked where safe-area pressure matters?
+
+## Suggested References
+
+- [ugui-popup.md](../unity-mcp-ui-layout/references/ugui-popup.md)
+- [ugui-anchors-canvas-scaler.md](../unity-mcp-ui-layout/references/ugui-anchors-canvas-scaler.md)
+- [ui-toolkit-layout-rules.md](../unity-mcp-ui-layout/references/ui-toolkit-layout-rules.md)
+- [text-layout-rules.md](../unity-mcp-ui-layout/references/text-layout-rules.md)
+- [layout-checklist.md](../unity-mcp-ui-layout/references/layout-checklist.md)
+- [scroll-view-patterns.md](../unity-mcp-ui-layout/references/scroll-view-patterns.md)


### PR DESCRIPTION
## Summary
- Add a settings/preferences dialog example for dense option screens with toggles, dropdowns, sliders, and apply/cancel actions.
- Index the new example by stack and by problem in examples/README.md.

## Why
This continues #40 by adding a copyable example for a common modal/configuration workflow that sits between UGUI popup rules, UI Toolkit container ownership, scroll ownership, and text layout rules.

## Validation
- git diff --check
- git diff --cached --check
- git diff --check HEAD~1..HEAD
- Verified all linked reference files exist with shell file checks
- rg -n "settings-dialog-example|Settings Dialog|Pick by Problem|settings body|apply/cancel|UGUI|UI Toolkit|portrait and landscape" examples/README.md examples/settings-dialog-example.md

Refs #40