### PR TITLE
[codex] Add responsive split pane example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - `current-vs-mockup-example.md`
 - `popup-safe-area-example.md`
 - `settings-dialog-example.md`
+- `responsive-split-pane-example.md`
 - `scroll-view-example.md`
 - `repair-one-region-example.md`
 - `repair-asset-aware-reuse-example.md`
@@ -43,7 +44,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - Start with `first-layout-pass-example.md` if you are new to the workflow or want one small structure-first practice task before choosing a domain-shaped example.
 - Start with `hud-example.md`, `inventory-example.md`, `popup-safe-area-example.md`, `settings-dialog-example.md`, or `mobile-safe-area-mockup-example.md` when the target is clearly UGUI.
 - Start with `scroll-view-example.md` when the main problem is list/feed/catalog scrolling plus repeated item reuse.
-- Start with `ui-toolkit-example.md` or `settings-dialog-example.md` when the target is clearly driven by `UIDocument`, `UXML`, and `USS`.
+- Start with `ui-toolkit-example.md`, `settings-dialog-example.md`, or `responsive-split-pane-example.md` when the target is clearly driven by `UIDocument`, `UXML`, and `USS`.
 - If the stack is not obvious yet, decide that first before choosing a task-shaped example.
 
 ## Pick by Problem
@@ -56,6 +57,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - Start with `asset-naming-example.md` when the task creates, promotes, or normalizes reusable UI assets.
 - Start with `localized-screen-example.md` or `long-labels-and-counters-example.md` when text growth is the main layout risk.
 - Start with `settings-dialog-example.md` when the screen is a dense options, preferences, pause-menu settings, or configuration dialog.
+- Start with `responsive-split-pane-example.md` when the screen has a left/right split, navigation rail plus detail panel, inspector view, or tablet-capable dashboard layout.
 - Start with `mobile-safe-area-mockup-example.md` when a mobile mockup ignores notch or home-indicator constraints.
 
 ## Suggested Reading Order
@@ -68,12 +70,13 @@ Use these files when you want a copyable starting point instead of only referenc
 6. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
 7. `popup-safe-area-example.md` if mobile safe area and modal structure matter
 8. `settings-dialog-example.md` if the screen is a dense options or preferences dialog
-9. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
-10. `repair-one-region-example.md` if the request should stay bounded to one named region
-11. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
-12. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
-13. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
-14. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
-15. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
-16. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
-17. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`
+9. `responsive-split-pane-example.md` if the screen uses a left/right split or tablet-capable dashboard layout
+10. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
+11. `repair-one-region-example.md` if the request should stay bounded to one named region
+12. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
+13. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
+14. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
+15. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
+16. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
+17. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
+18. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/responsive-split-pane-example.md
+++ b/examples/responsive-split-pane-example.md
@@ -1,0 +1,62 @@
+# Responsive Split Pane Example
+
+Use this example when the target is a desktop-style, tablet-capable, or editor-like screen with a stable left/right split, such as a list plus detail view, navigation rail plus content panel, inspector view, or management dashboard.
+
+## Scenario
+
+The user wants a split layout that looks stable at the main target width and still behaves intentionally at a narrower width. The goal is to define which container owns the horizontal split, which pane can compress, where scrolling begins, and how text behaves before tuning individual rows or cards.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to build or repair this responsive split-pane UI.
+Identify the active UI stack first and do not mix UGUI and UI Toolkit in one change unless I explicitly ask for a bridge.
+Define the top-level split owner before tuning leaf widgets.
+
+If this is UGUI, use a Canvas with CanvasScaler, then create stable major regions such as `ContentRoot -> LeftPane -> RightPane`.
+Use stretch anchors for the content body, give the left pane an intentional fixed/min width, and let the right pane own the remaining detail area.
+If this is UI Toolkit, inspect the UIDocument, UXML, USS, and visual tree first, then put horizontal split, min widths, flex grow/shrink, spacing, and overflow on containers rather than leaf elements.
+
+Decide the narrow-width behavior explicitly:
+- keep the left pane fixed and let the right pane compress
+- collapse the left pane to an icon rail
+- stack panes vertically
+- or require a wider/tablet layout only if the product explicitly allows that constraint
+
+Keep scroll ownership deliberate. If both panes contain long content, each pane may have its own scroll owner, but avoid nested scroll containers inside the same pane.
+Keep headers, filters, tabs, and footer actions outside a pane's scrolling content unless the design explicitly wants them to scroll.
+Turn repeated rows, cards, inspector fields, or navigation items into one reusable pattern instead of rebuilding each item by hand.
+Treat row labels, detail titles, counters, and metadata as layout drivers; decide whether they wrap, truncate, or reserve width before shrinking fonts.
+Verify at the main target width and one narrower width, and include a wider/tablet check if this screen is expected to support it.
+```
+
+## Why This Works
+
+- It makes the horizontal split a parent-container decision instead of a pile of leaf offsets.
+- It forces an explicit narrow-width strategy before flex or anchor defaults choose one accidentally.
+- It separates pane ownership from per-pane scrolling and repeated row/card layout.
+- It keeps text behavior from becoming an emergency font-size fix.
+- It gives tablet-capable or editor-style screens a verification target beyond the main width.
+
+## Decision Checklist
+
+- Is the active UI stack clear: UGUI or UI Toolkit?
+- Which parent owns the left/right split?
+- Does each pane have an intentional width, min width, or flex rule?
+- Is the narrow-width behavior named instead of left to defaults?
+- Are scroll owners limited to the panes that actually need scrolling?
+- Do fixed headers, filters, tabs, and footer actions stay outside the scrolling content where appropriate?
+- Are repeated rows or cards handled through a reusable pattern?
+- Were text wrapping, truncation, and value widths decided before font-size changes?
+- Was the layout checked at the main width and one narrower width?
+- Was a wider/tablet check included when the screen is expected to support it?
+
+## Suggested References
+
+- [ui-toolkit-layout-rules.md](../unity-mcp-ui-layout/references/ui-toolkit-layout-rules.md)
+- [ugui-anchors-canvas-scaler.md](../unity-mcp-ui-layout/references/ugui-anchors-canvas-scaler.md)
+- [scroll-view-patterns.md](../unity-mcp-ui-layout/references/scroll-view-patterns.md)
+- [text-layout-rules.md](../unity-mcp-ui-layout/references/text-layout-rules.md)
+- [mobile-device-profiles.md](../unity-mcp-ui-layout/references/mobile-device-profiles.md)
+- [review-checks.md](../unity-mcp-ui-layout/references/review-checks.md)
+- [layout-checklist.md](../unity-mcp-ui-layout/references/layout-checklist.md)


### PR DESCRIPTION
## Summary
- Add a responsive split-pane example for list/detail, navigation rail, inspector, and dashboard-style screens.
- Index the new example by UI Toolkit stack, problem shape, and suggested reading order.

## Why
This continues #40 by adding a copyable example for desktop/editor-style layouts where horizontal ownership, narrow-width behavior, scroll ownership, and text rules need to be deliberate.

## Validation
- git diff --check
- git diff --cached --check
- git diff --check HEAD~1..HEAD
- Verified all linked reference files exist with shell file checks
- rg -n "responsive-split-pane-example|Responsive Split Pane|Pick by Problem|split owner|narrower width|wider/tablet|left/right split|UIDocument|CanvasScaler|scroll owner|reusable pattern" examples/README.md examples/responsive-split-pane-example.md

Refs #40