### PR TITLE
[codex] Add tabbed detail screen example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - `popup-safe-area-example.md`
 - `settings-dialog-example.md`
 - `responsive-split-pane-example.md`
+- `tabbed-detail-screen-example.md`
 - `scroll-view-example.md`
 - `repair-one-region-example.md`
 - `repair-asset-aware-reuse-example.md`
@@ -43,7 +44,7 @@ Use these files when you want a copyable starting point instead of only referenc
 
 - Start with `first-layout-pass-example.md` if you are new to the workflow or want one small structure-first practice task before choosing a domain-shaped example.
 - Start with `hud-example.md`, `inventory-example.md`, `popup-safe-area-example.md`, `settings-dialog-example.md`, or `mobile-safe-area-mockup-example.md` when the target is clearly UGUI.
-- Start with `scroll-view-example.md` when the main problem is list/feed/catalog scrolling plus repeated item reuse.
+- Start with `scroll-view-example.md` or `tabbed-detail-screen-example.md` when the main problem is list/feed/catalog scrolling plus repeated item reuse.
 - Start with `ui-toolkit-example.md`, `settings-dialog-example.md`, or `responsive-split-pane-example.md` when the target is clearly driven by `UIDocument`, `UXML`, and `USS`.
 - If the stack is not obvious yet, decide that first before choosing a task-shaped example.
 
@@ -58,6 +59,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - Start with `localized-screen-example.md` or `long-labels-and-counters-example.md` when text growth is the main layout risk.
 - Start with `settings-dialog-example.md` when the screen is a dense options, preferences, pause-menu settings, or configuration dialog.
 - Start with `responsive-split-pane-example.md` when the screen has a left/right split, navigation rail plus detail panel, inspector view, or tablet-capable dashboard layout.
+- Start with `tabbed-detail-screen-example.md` when tabs, filters, or category buttons should stay fixed while selected content switches or scrolls.
 - Start with `mobile-safe-area-mockup-example.md` when a mobile mockup ignores notch or home-indicator constraints.
 
 ## Suggested Reading Order
@@ -71,12 +73,13 @@ Use these files when you want a copyable starting point instead of only referenc
 7. `popup-safe-area-example.md` if mobile safe area and modal structure matter
 8. `settings-dialog-example.md` if the screen is a dense options or preferences dialog
 9. `responsive-split-pane-example.md` if the screen uses a left/right split or tablet-capable dashboard layout
-10. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
-11. `repair-one-region-example.md` if the request should stay bounded to one named region
-12. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
-13. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
-14. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
-15. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
-16. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
-17. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
-18. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`
+10. `tabbed-detail-screen-example.md` if tabs, filters, or category buttons switch the visible content
+11. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
+12. `repair-one-region-example.md` if the request should stay bounded to one named region
+13. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
+14. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
+15. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
+16. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
+17. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
+18. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
+19. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/tabbed-detail-screen-example.md
+++ b/examples/tabbed-detail-screen-example.md
@@ -1,0 +1,55 @@
+# Tabbed Detail Screen Example
+
+Use this example when the target screen has tabs, filters, or category buttons that switch between detail panels, lists, or cards while shared chrome such as headers and footer actions should stay fixed.
+
+## Scenario
+
+The user wants a screen with a stable tab bar and a content area that changes by selected tab. The goal is to define tab ownership, content host ownership, scroll behavior, and tab label text rules before styling individual tab contents.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to build or repair this tabbed detail screen.
+Identify the active UI stack first and do not mix UGUI and UI Toolkit in one change unless I explicitly ask for a bridge.
+Build or repair the shell before styling individual tabs: `ScreenRoot -> Header -> TabBar -> ContentHost -> FooterActions`.
+
+Keep the TabBar, filters, header, and footer actions outside the scrolling content unless the design explicitly wants them to scroll.
+Make the TabBar one reusable tab-button pattern with clear selected, unselected, disabled, and overflow behavior.
+Decide whether tab labels should stay single-line, truncate, wrap, or move into a more compact mode before shrinking fonts.
+
+For UGUI, put tab buttons under a layout-owned row and keep active content under a bounded `ContentHost`; if the active tab has long content, use `ScrollRect -> Viewport -> Content` inside that tab panel.
+For UI Toolkit, inspect the UIDocument, UXML, USS, and visual tree first; keep tab row layout, selected-state styling, content switching, and overflow behavior in containers and reusable classes rather than leaf overrides.
+
+If each tab has repeated rows or cards, create one reusable row/card pattern inside that tab's content container.
+Verify the selected tab state, at least one alternate tab, longer tab labels, and a longer content set.
+Verify at the main target size and one narrower width or alternate aspect ratio before finalizing.
+```
+
+## Why This Works
+
+- It separates fixed navigation chrome from scrollable or switchable tab content.
+- It treats the tab button family as a reusable pattern instead of hand-styling each tab.
+- It gives tab labels explicit text behavior before font shrinking.
+- It keeps scroll ownership local to the active content panel.
+- It verifies more than the default selected tab.
+
+## Decision Checklist
+
+- Is the UI stack clear: UGUI or UI Toolkit?
+- Are Header, TabBar, ContentHost, and FooterActions owned by distinct parent regions?
+- Do tabs, filters, headers, and footer actions stay outside scrolling content where appropriate?
+- Is there one reusable tab-button pattern with selected, unselected, disabled, and overflow states?
+- Are tab label overflow rules explicit?
+- Does only the active content panel own scrolling when content is long?
+- Are repeated rows or cards inside tab content reusable?
+- Was at least one alternate tab checked, not only the default selected tab?
+- Was the layout checked with longer tab labels and a longer content set?
+
+## Suggested References
+
+- [scroll-view-patterns.md](../unity-mcp-ui-layout/references/scroll-view-patterns.md)
+- [text-layout-rules.md](../unity-mcp-ui-layout/references/text-layout-rules.md)
+- [ui-toolkit-layout-rules.md](../unity-mcp-ui-layout/references/ui-toolkit-layout-rules.md)
+- [ugui-anchors-canvas-scaler.md](../unity-mcp-ui-layout/references/ugui-anchors-canvas-scaler.md)
+- [review-checks.md](../unity-mcp-ui-layout/references/review-checks.md)
+- [prompt-patterns.md](../unity-mcp-ui-layout/references/prompt-patterns.md)


### PR DESCRIPTION
## Summary
- Add a tabbed detail screen example for fixed tabs/filters plus switchable or scrollable content.
- Index the new example by stack/problem shape and suggested reading order.

## Why
This continues #40 by adding a copyable example for tabbed screens where fixed navigation chrome, tab-button reuse, content-host ownership, scroll ownership, and tab label overflow must be deliberate.

## Validation
- git diff --check
- git diff --cached --check
- git diff --check HEAD~1..HEAD
- Verified all linked reference files exist with shell file checks
- rg -n "tabbed-detail-screen-example|Tabbed Detail Screen|TabBar|ContentHost|FooterActions|selected, unselected, disabled|alternate tab|longer tab labels|scrolling content|Pick by Problem" examples/README.md examples/tabbed-detail-screen-example.md

Refs #40