### PR TITLE
[codex] Add remaining example coverage

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,9 @@ Use these files when you want a copyable starting point instead of only referenc
 - `hud-example.md`
 - `inventory-example.md`
 - `mockup-resolution-example.md`
+- `mockup-decomposition-example.md`
 - `mobile-safe-area-mockup-example.md`
+- `mobile-device-profile-verification-example.md`
 - `current-vs-mockup-example.md`
 - `popup-safe-area-example.md`
 - `settings-dialog-example.md`
@@ -51,6 +53,8 @@ Use these files when you want a copyable starting point instead of only referenc
 ## Pick by Problem
 
 - Start with `first-layout-pass-example.md` when you need a small build-mode exercise before choosing a domain-shaped example.
+- Start with `mockup-resolution-example.md` when the mockup's own pixel resolution should drive planning.
+- Start with `mockup-decomposition-example.md` when the main question is what should stay baked, what should split, and what should become a reusable block before layout work begins.
 - Start with `current-vs-mockup-example.md` when the existing screen should be compared against a reference before repair.
 - Start with `repair-one-region-example.md` when the request must stay bounded to one named region.
 - Start with `repair-asset-aware-reuse-example.md` when the repair may touch reusable prefabs, variants, wrappers, shared sprites, materials, or text styles.
@@ -61,6 +65,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - Start with `responsive-split-pane-example.md` when the screen has a left/right split, navigation rail plus detail panel, inspector view, or tablet-capable dashboard layout.
 - Start with `tabbed-detail-screen-example.md` when tabs, filters, or category buttons should stay fixed while selected content switches or scrolls.
 - Start with `mobile-safe-area-mockup-example.md` when a mobile mockup ignores notch or home-indicator constraints.
+- Start with `mobile-device-profile-verification-example.md` when a mobile-first screen needs explicit verification across a standard phone, a taller phone, and a wider mobile or tablet profile.
 
 ## Suggested Reading Order
 
@@ -68,18 +73,20 @@ Use these files when you want a copyable starting point instead of only referenc
 2. `hud-example.md` if you are starting with a composition-driven overlay
 3. `inventory-example.md` if your UI is slot- or list-based
 4. `mockup-resolution-example.md` if the mockup's native pixel resolution should drive planning
-5. `current-vs-mockup-example.md` if the screen already exists and should be compared against a reference image first
-6. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
-7. `popup-safe-area-example.md` if mobile safe area and modal structure matter
-8. `settings-dialog-example.md` if the screen is a dense options or preferences dialog
-9. `responsive-split-pane-example.md` if the screen uses a left/right split or tablet-capable dashboard layout
-10. `tabbed-detail-screen-example.md` if tabs, filters, or category buttons switch the visible content
-11. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
-12. `repair-one-region-example.md` if the request should stay bounded to one named region
-13. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
-14. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
-15. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
-16. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
-17. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
-18. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
-19. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`
+5. `mockup-decomposition-example.md` if the main question is what should stay baked, split, or become reusable
+6. `current-vs-mockup-example.md` if the screen already exists and should be compared against a reference image first
+7. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
+8. `mobile-device-profile-verification-example.md` if a mobile-first screen needs named profile coverage before approval
+9. `popup-safe-area-example.md` if mobile safe area and modal structure matter
+10. `settings-dialog-example.md` if the screen is a dense options or preferences dialog
+11. `responsive-split-pane-example.md` if the screen uses a left/right split or tablet-capable dashboard layout
+12. `tabbed-detail-screen-example.md` if tabs, filters, or category buttons switch the visible content
+13. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
+14. `repair-one-region-example.md` if the request should stay bounded to one named region
+15. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
+16. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
+17. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
+18. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
+19. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
+20. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
+21. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/mobile-device-profile-verification-example.md
+++ b/examples/mobile-device-profile-verification-example.md
@@ -1,0 +1,53 @@
+# Mobile Device Profile Verification Example
+
+Use this example when a mobile-first UI should be verified across device shapes before it is called stable.
+
+## Scenario
+
+- A mobile UI already exists or has just been built.
+- One portrait screenshot looks acceptable, but the product has not ruled out taller phones, wider mobile layouts, or tablet-like profiles.
+- The task is verification and targeted repair, not a full rebuild.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to verify this mobile-first UI across device profiles before calling it complete.
+Treat this as a verification pass, not a rebuild.
+Identify the active UI stack first and do not mix UGUI and UI Toolkit in one change unless I explicitly ask for a bridge.
+
+Use the project's main target profile as the baseline.
+If no exact device list is specified, verify:
+1. the standard phone or main target profile
+2. one taller phone profile
+3. one wider mobile or small tablet profile when the product may support it
+
+If the product is tablet-capable, include one explicit tablet-like verification pass.
+Do not assume portrait-only unless the product or task explicitly says so.
+For each profile, inspect the result and report changes in anchors, safe-area pressure, spacing, clipping, scroll or content fit, text fit, and panel balance.
+Apply only the smallest structural fix needed for a verified issue, then repeat the affected profile check and the main target check.
+```
+
+## Why This Works
+
+- It turns "looks good on mobile" into named verification coverage.
+- It keeps the main target as the baseline instead of comparing only alternate profiles.
+- It catches tall-phone safe-area pressure and wider-profile spacing drift.
+- It prevents portrait-only assumptions from being made silently.
+- It keeps fixes targeted to verified profile failures.
+
+## Decision Checklist
+
+- Was the main target profile checked first?
+- Was one taller phone profile checked?
+- Was one wider mobile or small tablet profile checked, or explicitly ruled out by product scope?
+- Was a tablet-like pass included when tablet support matters?
+- Were anchors, spacing, clipping, text fit, scroll fit, safe-area behavior, and panel balance compared across profiles?
+- Did any fix get rechecked on the affected profile and the main target profile?
+
+## Suggested References
+
+- [mobile-device-profiles.md](../unity-mcp-ui-layout/references/mobile-device-profiles.md)
+- [review-checks.md](../unity-mcp-ui-layout/references/review-checks.md)
+- [prompt-patterns.md](../unity-mcp-ui-layout/references/prompt-patterns.md)
+- [ugui-mobile-safe-area.md](../unity-mcp-ui-layout/references/ugui-mobile-safe-area.md)
+- [ui-toolkit-layout-rules.md](../unity-mcp-ui-layout/references/ui-toolkit-layout-rules.md)

--- a/examples/mockup-decomposition-example.md
+++ b/examples/mockup-decomposition-example.md
@@ -1,0 +1,49 @@
+# Mockup Decomposition Example
+
+Use this example when a mockup exists and the main risk is splitting visual regions too much, or not splitting runtime-owned parts enough.
+
+## Scenario
+
+- A mockup image exists.
+- The UI may contain baked decorative art, repeated cards or rows, and interactive widgets.
+- The task needs a decomposition decision before layout tuning or pixel matching.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to build this UI from the attached mockup.
+Before creating objects, inspect the mockup and write a decomposition pass:
+- top-level anchor-owned regions
+- repeated groups that should become reusable blocks or prefabs
+- runtime-owned widgets that need interaction, dynamic text, state, animation, safe-area behavior, or adaptive layout
+- decorative or baked regions that should stay as one image or sprite region
+
+Decompose by runtime responsibility, not by visual outline alone.
+Keep decorative panels, ornaments, and baked art whole unless runtime behavior requires separation.
+Do not trace every visible seam into a child object.
+Turn repeated cards, rows, slots, button groups, or badge clusters into one reusable pattern before placing copies.
+After the decomposition pass, build parent containers before leaf widgets and keep likely single-image regions simple.
+Verify that every split has a runtime reason and that no repeated block was rebuilt manually.
+```
+
+## Why This Works
+
+- It makes asset granularity a deliberate decision before layout work starts.
+- It prevents fake child objects that only mirror visual edges in the mockup.
+- It keeps interactive, stateful, and adaptive parts separate from baked art.
+- It promotes repeated structures into reusable blocks instead of one-off copies.
+
+## Decision Checklist
+
+- Can each split be justified by interaction, dynamic data, state, animation, safe-area behavior, or adaptive layout?
+- Did decorative panels, ornaments, and baked art stay whole where possible?
+- Are repeated cards, rows, slots, button groups, or badge clusters represented by one reusable pattern?
+- Are top-level regions grouped before atomic widgets are tuned?
+- Would another engineer understand why each region exists at runtime?
+
+## Suggested References
+
+- [mockup-decomposition.md](../unity-mcp-ui-layout/references/mockup-decomposition.md)
+- [image-to-layout.md](../unity-mcp-ui-layout/references/image-to-layout.md)
+- [mockup-resolution.md](../unity-mcp-ui-layout/references/mockup-resolution.md)
+- [prompt-patterns.md](../unity-mcp-ui-layout/references/prompt-patterns.md)


### PR DESCRIPTION
## Summary
- Add a mockup decomposition example for deciding what stays baked, what becomes runtime-owned UI, and what becomes reusable before layout work begins.
- Add a mobile device profile verification example for checking a mobile-first UI against the main target, a taller phone, and a wider mobile or tablet profile.
- Index both examples in the examples README by list, problem, and suggested reading order.

## Why
This completes the remaining highest-value example gaps from #40: mockup decomposition and mobile profile verification. The examples stay focused on copyable prompts and avoid duplicating existing mockup-resolution or safe-area construction examples.

## Validation
- git diff --check
- git diff --check HEAD~1..HEAD
- Verified every README Included Examples entry maps to an existing file
- Verified all new Suggested References targets exist
- rg -n "mockup-decomposition-example|mobile-device-profile-verification-example|runtime responsibility|wider mobile|taller phone|standard phone|what should stay baked|profile coverage" examples/README.md examples/mockup-decomposition-example.md examples/mobile-device-profile-verification-example.md

Closes #40