### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,36 +1,30 @@
 # Backlog
 
-This backlog tracks likely next improvements for the repository after `v0.4.0` and the follow-up documentation passes that landed afterward.
+This backlog tracks likely next improvements for the repository after `v0.4.1`.
 
-이 backlog는 `v0.4.0` 이후와 그 뒤에 이어진 문서 보강 이후, 다음에 다듬을 만한 항목을 정리합니다.
+이 backlog는 `v0.4.1` 이후, 다음에 다듬을 만한 항목을 정리합니다.
 
 ## High Priority / 높은 우선순위
 
-### 1. Repository Polish
-
-- add bilingual sections to platform READMEs where the current guidance still feels English-heavy
-- add a short architecture note that explains how `SKILL.md`, `references/`, `examples/`, and `Platform/` relate
-
-### 2. Example Expansion
+### 1. Example Expansion
 
 - add more domain-shaped examples such as shop, reward screen, and profile screen
-- add examples that mix repair mode with asset-aware mode more explicitly
+- add one example that compares two candidate repair strategies before choosing one
 
 ## Medium Priority / 중간 우선순위
 
-### 3. Verification Set Expansion
+### 2. Verification Set Expansion
 
-- add more side-by-side verification examples for tablet-capable layouts
-- add one example that compares two candidate repair strategies before choosing one
+- add one side-by-side verification example for tablet-capable layouts with explicit profile comparison
 
-### 4. Platform Adapter Depth
+### 3. Platform Adapter Depth
 
 - extend platform adapters with a few more service-specific usage examples
 - tighten wording where a platform still sounds more generic than the Codex source skill
 
 ## Low Priority / 낮은 우선순위
 
-### 5. Maintenance Automation
+### 4. Maintenance Automation
 
 - consider a small automation or helper note for routine release prep
 - consider a lightweight reminder pattern for syncing platform docs after larger skill releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ This project follows a lightweight documentation-focused release flow.
 
 이 프로젝트는 문서 중심의 가벼운 릴리스 흐름을 따릅니다.
 
+## v0.4.1 - 2026-04-23
+
+### Added
+
+- Expanded the practical example catalog with beginner first-layout, current-vs-mockup, localized text, long-label, scroll-view, settings dialog, responsive split-pane, tabbed detail screen, mockup decomposition, mobile device profile verification, and repair asset-aware reuse prompts
+- Added mobile device profile guidance for checking a main target, taller phone, and wider mobile or tablet profile before approving mobile-first layouts
+- Added release and maintenance notes for issue-to-release flow, release-prep checks, and repository upkeep
+
+### Added / 추가
+
+- beginner first-layout, current-vs-mockup, localized text, long-label, scroll-view, settings dialog, responsive split-pane, tabbed detail screen, mockup decomposition, mobile device profile verification, repair asset-aware reuse 프롬프트로 실전 예시 카탈로그 확장
+- 모바일 우선 레이아웃을 승인하기 전에 main target, taller phone, wider mobile/tablet profile을 확인하는 mobile device profile 가이드 추가
+- issue부터 release까지의 흐름, release prep 체크, 저장소 유지보수에 대한 운영 문서 추가
+
+### Changed
+
+- Tightened skill onboarding, routing, completion gates, prompt patterns, layout checks, and review checks around the new example coverage
+- Updated platform and root repository documentation with bilingual navigation and a clearer explanation of how `SKILL.md`, `references/`, `examples/`, and `Platform/` fit together
+- Refreshed the backlog so shipped repository-polish and example-coverage work is no longer listed as open
+
+### Changed / 변경
+
+- 새 예시 커버리지에 맞춰 skill onboarding, routing, completion gate, prompt pattern, layout check, review check 문구 정리
+- `SKILL.md`, `references/`, `examples/`, `Platform/`의 관계가 더 잘 보이도록 platform 문서와 루트 저장소 문서의 한영 안내 보강
+- 이미 반영된 repository polish와 example coverage 작업이 열린 backlog처럼 보이지 않도록 backlog 정리
+
 ## v0.4.0 - 2026-04-02
 
 ### Added


### PR DESCRIPTION
## Summary
- Add the v0.4.1 changelog entry for the post-v0.4.0 documentation and example updates.
- Refresh BACKLOG.md so shipped repository-polish and example-coverage work is no longer listed as open.

## Validation
- git diff --check
- git diff --check HEAD~1..HEAD
- python3 /Users/song/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/song/.codex/worktrees/e6b2/unity-mcp-ui-layout/unity-mcp-ui-layout
- rg -n "v0\.4\.1 - 2026-04-23|after `v0\.4\.1`|Repository Polish" CHANGELOG.md BACKLOG.md

Closes #46