### PR TITLE
[codex] Add DESIGN.md intake guidance

### DIFF
--- a/Platform/Claude-Artifacts/ARTIFACT_PROMPT.md
+++ b/Platform/Claude-Artifacts/ARTIFACT_PROMPT.md
@@ -20,6 +20,7 @@ Treat the artifact as a structured layout plan, not just a visual guess. The art
 - Keep likely single-image regions intact unless interaction, animation, or adaptive behavior requires them to be split.
 - Treat text as a layout driver and decide wrapping, truncation, or container growth before shrinking fonts.
 - If a mobile mockup is notch-agnostic, preserve its composition inside the safe area instead of copying raw top and bottom edge pixels.
+- If the user provides `DESIGN.md`, design tokens, or a style guide, read that source before styling and preserve its color, typography, spacing, shape, component state, and prose intent where practical.
 - Before editing shared prefabs, sprites, materials, or TMP styles directly, decide whether the change should stay local through a variant, wrapper, or local override.
 
 ## What the Artifact Should Emphasize
@@ -30,6 +31,7 @@ Treat the artifact as a structured layout plan, not just a visual guess. The art
 - `CanvasScaler` or flex behavior
 - safe-area ownership when relevant
 - text role and overflow behavior when relevant
+- design-system token and prose intent when provided
 - what was changed in the current step
 - what should be verified next
 
@@ -68,5 +70,6 @@ For each iteration:
 - Explain layout intent in terms of regions, anchors, scaling, and parent ownership.
 - Be explicit about tradeoffs when a design seems too dependent on exact pixels.
 - When a popup or mobile layout is involved, call out safe-area ownership directly.
+- When a design-system source is provided, call out how styling traces back to it.
 - When a shared asset might be edited, call out the safety decision directly.
 - Prefer clear artifact sections such as `Plan`, `Current Change`, `Verification`, and `Next Step`.

--- a/Platform/Codex/README.md
+++ b/Platform/Codex/README.md
@@ -17,6 +17,7 @@ Use the root skill folder directly:
 - mockup-native resolution guidance
 - mockup decomposition rules
 - repair mode versus build mode rules
+- DESIGN.md and design-token intake rules
 - asset discovery priority and asset naming/folder rules
 - text layout rules
 - notch-agnostic mockup to safe-area mapping
@@ -26,6 +27,7 @@ Use the root skill folder directly:
 - 시안 원본 해상도 기준 규칙
 - 시안 분해 기준
 - repair mode / build mode 규칙
+- DESIGN.md 및 design token intake 규칙
 - 자산 탐색 우선순위와 자산 네이밍/폴더 규칙
 - 텍스트 레이아웃 규칙
 - 노치 없는 시안을 safe area 레이아웃으로 재해석하는 규칙
@@ -50,10 +52,12 @@ cp -R ./unity-mcp-ui-layout ~/.codex/skills/
 
 ```text
 Use $unity-mcp-ui-layout to build or fix a Unity UI layout from a mockup, screenshot, or target resolution.
+If DESIGN.md or design tokens are provided, read them before styling.
 ```
 
 ```text
 $unity-mcp-ui-layout를 사용해서 목업, 스크린샷, 목표 해상도를 기준으로 Unity UI 레이아웃을 만들거나 수정해줘.
+DESIGN.md나 design token이 제공되면 스타일링 전에 먼저 읽어줘.
 ```
 
 ## Example User Prompts / 예시 사용자 프롬프트

--- a/Platform/Google-Antigravity/SYSTEM_PROMPT.md
+++ b/Platform/Google-Antigravity/SYSTEM_PROMPT.md
@@ -19,6 +19,7 @@ Do this by prioritizing:
 - screenshot verification after each structural change
 - text layout decisions before emergency font shrinking
 - safe-area-aware reinterpretation of notch-agnostic mobile mockups
+- DESIGN.md or design-token sources before visual styling when provided
 - cautious handling of shared asset families
 
 ## Execution Rules
@@ -32,6 +33,7 @@ Do this by prioritizing:
 - If a region appears to be a single image resource, do not force it into fake sub-widgets unless runtime behavior needs them.
 - Treat text as a layout driver and decide wrapping, truncation, or container growth before shrinking fonts.
 - If a mobile mockup ignores notches or home indicators, preserve its composition inside the safe area instead of copying raw top and bottom edge pixels.
+- If the user provides `DESIGN.md`, design tokens, or a style guide, read that source before styling and preserve its color, typography, spacing, shape, component state, and prose intent where practical.
 - Before editing a shared prefab, sprite, material, or text style directly, decide whether the change should stay local through a variant, wrapper, or override.
 - If the layout is wrong, repair structure before styling.
 
@@ -79,6 +81,7 @@ When an image and target resolution are provided:
 - If scripts change, refresh, wait for compile, and inspect console errors before continuing.
 - If a popup or mobile screen is involved, explicitly verify safe-area behavior.
 - If shared assets were touched directly, verify that the change really belongs to the shared contract.
+- If a design-system source was provided, verify that visible styling still follows it or that deviations were justified.
 
 ## Output Behavior
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ If you are using this repository for the first time, do not start by reading eve
 2. Choose the UI stack first: `UGUI` or `UI Toolkit`.
 3. Choose the change mode next: repair an existing screen or build a new one.
 4. Decide whether this is layout-only work or asset-aware reuse work.
-5. Then open [`examples/README.md`](./examples/README.md) for a task-shaped entry point, or jump into [`unity-mcp-ui-layout/references/README.md`](./unity-mcp-ui-layout/references/README.md) if you already know the failure mode.
+5. If the task includes `DESIGN.md`, design tokens, or a design-system source, read that source before styling.
+6. Then open [`examples/README.md`](./examples/README.md) for a task-shaped entry point, or jump into [`unity-mcp-ui-layout/references/README.md`](./unity-mcp-ui-layout/references/README.md) if you already know the failure mode.
 
 For a first small exercise, start with [`examples/first-layout-pass-example.md`](./examples/first-layout-pass-example.md) before choosing a more domain-specific example.
 
@@ -40,7 +41,8 @@ For a first small exercise, start with [`examples/first-layout-pass-example.md`]
 2. UI 스택을 먼저 고릅니다: `UGUI` 또는 `UI Toolkit`.
 3. 그다음 기존 화면 수정인지, 신규 화면 생성인지 작업 모드를 고릅니다.
 4. 이 작업이 layout-only인지, asset-aware reuse까지 필요한지 결정합니다.
-5. 그 후 작업형 진입점이 필요하면 [`examples/README.md`](./examples/README.md)를, 실패 유형을 이미 알고 있다면 [`unity-mcp-ui-layout/references/README.md`](./unity-mcp-ui-layout/references/README.md)를 엽니다.
+5. 작업에 `DESIGN.md`, design token, design-system source가 포함되어 있다면 스타일링 전에 그 소스를 먼저 읽습니다.
+6. 그 후 작업형 진입점이 필요하면 [`examples/README.md`](./examples/README.md)를, 실패 유형을 이미 알고 있다면 [`unity-mcp-ui-layout/references/README.md`](./unity-mcp-ui-layout/references/README.md)를 엽니다.
 
 처음 해볼 작은 연습 과제가 필요하다면 더 구체적인 예시를 고르기 전에 [`examples/first-layout-pass-example.md`](./examples/first-layout-pass-example.md)부터 시작합니다.
 
@@ -98,6 +100,8 @@ Platform-specific adapters live in:
 - mockup-native resolution rules when a design image exists
 - mockup decomposition rules for deciding what should stay baked, what should split, and what should become reusable blocks
 - repair mode vs greenfield build mode rules for existing-screen fixes versus new UI creation
+- DESIGN.md and design-token intake rules for preserving colors, typography, spacing, shapes, component states, and prose intent
+- Unity mapping rules for translating design-system tokens into UGUI, TextMeshPro, UI Toolkit, and USS
 - asset discovery priority rules for prefab, sprite, font, material, and placeholder reuse order
 - asset naming and folder rules so reusable assets stay discoverable and screen-owned assets stay scoped correctly
 - practical naming and folder examples for shared versus screen-owned assets and variant family organization
@@ -125,6 +129,8 @@ Platform-specific adapters live in:
 - 시안 이미지가 있을 때 시안의 원본 해상도를 기준 프레임으로 삼는 규칙
 - 시안 요소를 어디까지 분해하고 어디를 단일 자산이나 재사용 블록으로 유지할지에 대한 규칙
 - 기존 UI 수정 요청과 신규 UI 생성 요청을 구분하는 작업 모드 규칙
+- 색상, 타이포그래피, 간격, 모양, 컴포넌트 상태, prose intent를 보존하기 위한 DESIGN.md 및 design token intake 규칙
+- design-system token을 UGUI, TextMeshPro, UI Toolkit, USS로 옮기기 위한 Unity 매핑 규칙
 - 프리팹, 스프라이트, 폰트, 머티리얼, 플레이스홀더를 어떤 순서로 찾을지에 대한 자산 탐색 우선순위 규칙
 - 재사용 자산은 다시 찾기 쉽고 화면 전용 자산은 범위가 드러나도록 만드는 자산 네이밍/폴더 규칙
 - shared vs screen-owned 자산과 variant family 구성을 실제 트리로 보여주는 실전 예시

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Use these files when you want a copyable starting point instead of only referenc
 ## Quick Rules
 
 - Group the top-level layout by anchor-owned regions before tuning leaf widgets.
+- Read provided `DESIGN.md` or design-token sources before styling.
 - Reuse repeated structures through prefabs or reusable layout blocks.
 - Keep likely single-image regions intact unless runtime behavior requires decomposition.
 - Verify structure with screenshots instead of chasing raw pixel alignment.
@@ -18,6 +19,8 @@ Use these files when you want a copyable starting point instead of only referenc
 - `inventory-example.md`
 - `mockup-resolution-example.md`
 - `mockup-decomposition-example.md`
+- `design-md-layout-example.md`
+- `design-md-repair-example.md`
 - `mobile-safe-area-mockup-example.md`
 - `mobile-device-profile-verification-example.md`
 - `current-vs-mockup-example.md`
@@ -55,6 +58,8 @@ Use these files when you want a copyable starting point instead of only referenc
 - Start with `first-layout-pass-example.md` when you need a small build-mode exercise before choosing a domain-shaped example.
 - Start with `mockup-resolution-example.md` when the mockup's own pixel resolution should drive planning.
 - Start with `mockup-decomposition-example.md` when the main question is what should stay baked, what should split, and what should become a reusable block before layout work begins.
+- Start with `design-md-layout-example.md` when a new screen should be built from a mockup plus `DESIGN.md` or design-token inputs.
+- Start with `design-md-repair-example.md` when an existing screen should be repaired against `DESIGN.md` without drifting from shared tokens.
 - Start with `current-vs-mockup-example.md` when the existing screen should be compared against a reference before repair.
 - Start with `repair-one-region-example.md` when the request must stay bounded to one named region.
 - Start with `repair-asset-aware-reuse-example.md` when the repair may touch reusable prefabs, variants, wrappers, shared sprites, materials, or text styles.
@@ -74,19 +79,21 @@ Use these files when you want a copyable starting point instead of only referenc
 3. `inventory-example.md` if your UI is slot- or list-based
 4. `mockup-resolution-example.md` if the mockup's native pixel resolution should drive planning
 5. `mockup-decomposition-example.md` if the main question is what should stay baked, split, or become reusable
-6. `current-vs-mockup-example.md` if the screen already exists and should be compared against a reference image first
-7. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
-8. `mobile-device-profile-verification-example.md` if a mobile-first screen needs named profile coverage before approval
-9. `popup-safe-area-example.md` if mobile safe area and modal structure matter
-10. `settings-dialog-example.md` if the screen is a dense options or preferences dialog
-11. `responsive-split-pane-example.md` if the screen uses a left/right split or tablet-capable dashboard layout
-12. `tabbed-detail-screen-example.md` if tabs, filters, or category buttons switch the visible content
-13. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
-14. `repair-one-region-example.md` if the request should stay bounded to one named region
-15. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
-16. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
-17. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
-18. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
-19. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
-20. `shared-asset-verification-example.md` if you need a concrete “check another usage first” prompt for shared assets
-21. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`
+6. `design-md-layout-example.md` if a new screen should follow `DESIGN.md` tokens and prose intent
+7. `design-md-repair-example.md` if an existing screen should be repaired while preserving `DESIGN.md`
+8. `current-vs-mockup-example.md` if the screen already exists and should be compared against a reference image first
+9. `mobile-safe-area-mockup-example.md` if the mockup ignores notch or home-indicator constraints
+10. `mobile-device-profile-verification-example.md` if a mobile-first screen needs named profile coverage before approval
+11. `popup-safe-area-example.md` if mobile safe area and modal structure matter
+12. `settings-dialog-example.md` if the screen is a dense options or preferences dialog
+13. `responsive-split-pane-example.md` if the screen uses a left/right split or tablet-capable dashboard layout
+14. `tabbed-detail-screen-example.md` if tabs, filters, or category buttons switch the visible content
+15. `scroll-view-example.md` if the core challenge is scroll ownership plus reusable repeated rows or cards
+16. `repair-one-region-example.md` if the request should stay bounded to one named region
+17. `repair-asset-aware-reuse-example.md` if a repair may need prefab reuse, variants, wrappers, or shared-asset impact checks
+18. `asset-naming-example.md` if the task also needs shared-versus-screen asset cleanup
+19. `localized-screen-example.md` if the screen must survive both short English and longer localized strings
+20. `long-labels-and-counters-example.md` if long labels, body text, and number growth compete for the same layout
+21. `shared-asset-safety-example.md` if a repair might touch shared prefabs or other shared UI assets
+22. `shared-asset-verification-example.md` if you need a concrete "check another usage first" prompt for shared assets
+23. `ui-toolkit-example.md` if the target screen is clearly driven by `UIDocument`, `UXML`, and `USS`

--- a/examples/design-md-layout-example.md
+++ b/examples/design-md-layout-example.md
@@ -1,0 +1,37 @@
+# DESIGN.md Layout Example
+
+Use this example when you are building a new Unity UI screen from a mockup plus a `DESIGN.md` or design-token document.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to build a new [screen name] UI from the attached mockup and DESIGN.md.
+Read DESIGN.md before editing anything.
+Extract the design tokens and the prose intent: spacing, color, typography, radius, component states, density, hierarchy, and any layout stability rules.
+Identify the active UI stack:
+- For UGUI/TMP, map tokens to CanvasScaler, RectTransform anchors, TMP styles, sprites, materials, and reusable prefabs where appropriate.
+- For UI Toolkit, map tokens to UXML structure, USS variables/classes, VisualElement layout, typography, and reusable templates where appropriate.
+- If both stacks appear possible, ask before editing.
+
+Create the screen structure from containers outward.
+Preserve layout stability rules from DESIGN.md, including safe areas, fixed versus flexible regions, wrapping/truncation behavior, scroll ownership, and alternate aspect ratios.
+Do not invent local colors, fonts, spacing, or component styles when DESIGN.md already defines them.
+If component tokens define both text and background colors, check their contrast in the implemented state.
+Verify with screenshots at the main target resolution and one alternate aspect ratio.
+Report which tokens were applied, any DESIGN.md gaps, the screenshot checks, and any contrast concerns.
+```
+
+## Why This Works
+
+- It treats `DESIGN.md` as the source of truth before the mockup is translated.
+- It maps tokens differently for UGUI/TMP and UI Toolkit instead of mixing stack rules.
+- It keeps responsive behavior and contrast checks inside the first build pass.
+
+## Suggested References
+
+- [design-system-intake.md](../unity-mcp-ui-layout/references/design-system-intake.md)
+- [design-token-to-unity.md](../unity-mcp-ui-layout/references/design-token-to-unity.md)
+- [layout-checklist.md](../unity-mcp-ui-layout/references/layout-checklist.md)
+- [ugui-anchors-canvas-scaler.md](../unity-mcp-ui-layout/references/ugui-anchors-canvas-scaler.md)
+- [ui-toolkit-layout-rules.md](../unity-mcp-ui-layout/references/ui-toolkit-layout-rules.md)
+- [text-layout-rules.md](../unity-mcp-ui-layout/references/text-layout-rules.md)

--- a/examples/design-md-repair-example.md
+++ b/examples/design-md-repair-example.md
@@ -1,0 +1,36 @@
+# DESIGN.md Repair Example
+
+Use this example when an existing Unity UI screen should be repaired while preserving a provided `DESIGN.md` or design-token document.
+
+## Example Prompt
+
+```text
+Use $unity-mcp-ui-layout to repair the existing [screen name] UI while preserving DESIGN.md.
+Read DESIGN.md before editing anything.
+Keep the repair bounded to [named region or specific problem].
+Inspect the current UI stack, parent chain, shared prefabs/styles, and any local overrides before changing values.
+
+Compare the current screen against DESIGN.md tokens and prose intent.
+Detect style drift: local colors, fonts, spacing, radii, TMP styles, USS classes, sprites, or materials that do not match the design source.
+Do not replace drift with new random local values; either restore the matching DESIGN.md token/style or explain why the screen needs a scoped override.
+If a shared prefab, TMP style, material, sprite, USS selector, or UXML template is involved, check other usages before editing the shared asset.
+Prefer a variant, wrapper, or local override when the repair is screen-specific.
+Preserve existing behavior outside the bounded repair area unless the parent structure directly causes the issue.
+Verify with a before/after screenshot at the main target resolution and one alternate aspect ratio if layout could shift.
+Report the drift found, the bounded changes made, shared-asset safety checks, and any DESIGN.md gaps.
+```
+
+## Why This Works
+
+- It repairs against the design source instead of eyeballing a new style.
+- It prevents one-screen fixes from leaking into shared assets.
+- It keeps the agent focused on the named problem area.
+
+## Suggested References
+
+- [design-system-intake.md](../unity-mcp-ui-layout/references/design-system-intake.md)
+- [design-token-to-unity.md](../unity-mcp-ui-layout/references/design-token-to-unity.md)
+- [ui-change-modes.md](../unity-mcp-ui-layout/references/ui-change-modes.md)
+- [common-failures.md](../unity-mcp-ui-layout/references/common-failures.md)
+- [shared-asset-edit-safety.md](../unity-mcp-ui-layout/references/shared-asset-edit-safety.md)
+- [prompt-patterns.md](../unity-mcp-ui-layout/references/prompt-patterns.md)

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unity-mcp-ui-layout
-description: Use when Unity UI needs layout-focused repair or implementation through `unity-mcp`, especially for UGUI or UI Toolkit screens with cross-resolution drift, safe-area problems, text overflow, mockup translation, or shared prefab reuse decisions.
+description: Use when Unity UI needs layout-focused repair or implementation through `unity-mcp`, especially for UGUI or UI Toolkit screens with cross-resolution drift, safe-area problems, text overflow, mockup translation, DESIGN.md or design-token inputs, or shared prefab reuse decisions.
 ---
 
 # Unity MCP UI Layout
@@ -18,6 +18,7 @@ Use this skill for Unity UI work where layout stability matters more than raw pi
 - A UI Toolkit screen looks correct once but breaks after width, overflow, or text changes.
 - A scroll-heavy list, feed, catalog, or picker mockup needs one clear scroll owner plus reusable repeated items.
 - Safe area, localization, counters, or long labels are destabilizing the layout.
+- A `DESIGN.md`, `design_tokens.json`, Tailwind theme, or similar design-system source should guide Unity UI styling.
 - A repeated UI block should become reusable instead of being rebuilt manually.
 - A one-screen repair may touch shared prefabs, sprites, materials, or text styles.
 
@@ -30,7 +31,7 @@ Use this skill for Unity UI work where layout stability matters more than raw pi
 
 ## Quick Router
 
-Choose these three boundaries before editing anything:
+Choose these four boundaries before editing anything:
 
 ### 1. UI Stack
 
@@ -46,7 +47,15 @@ Choose these three boundaries before editing anything:
 
 For the full decision guide, read `references/ui-change-modes.md`.
 
-### 3. Asset Strategy
+### 3. Design Source
+
+- If the user provides `DESIGN.md`, design tokens, Tailwind theme values, or a design-system document, read it before styling.
+- Treat machine-readable tokens as the style contract and Markdown prose as intent for applying those values.
+- Use design-source guidance to preserve color, typography, spacing, shape, component states, and accessibility while still following layout stability rules.
+
+For the intake and Unity mapping rules, read `references/design-system-intake.md` and `references/design-token-to-unity.md`.
+
+### 4. Asset Strategy
 
 - Start in **layout-only mode** by default.
 - Switch to **asset-aware mode** only when existing prefab, sprite, font, material, or design-system reuse clearly matters.
@@ -56,6 +65,8 @@ For the full decision guide, read `references/ui-change-modes.md`.
 
 - This skill assumes Unity is available through `unity-mcp` or an equivalent MCP bridge.
 - It works best when you can inspect the current scene or UI document and verify with screenshots.
+- If a `DESIGN.md` or token source is present, style decisions should be traced back to that source where practical.
+- `@google/design.md` CLI checks are useful when available, but missing CLI tooling is a supported fallback.
 - Use asset-aware retrieval only when the environment supports it and the task actually needs reuse-sensitive decisions.
 - If asset retrieval is unavailable or low-confidence, continue with structure-first layout work, use placeholders or directly inspected assets, and keep uncertain visuals provisional.
 
@@ -63,6 +74,7 @@ For the full decision guide, read `references/ui-change-modes.md`.
 
 - The layout stays stable in a fresh screenshot at the main target and one additional aspect ratio.
 - Text still behaves correctly with longer strings, counters, or localization growth.
+- If a design-system source was provided, visible colors, typography, spacing, shape, and component states still follow it.
 - Shared assets were either left alone, localized through variants/wrappers, or explicitly verified before base edits.
 - Script-backed UI changes do not leave unresolved compile or console errors.
 
@@ -71,7 +83,8 @@ For the full decision guide, read `references/ui-change-modes.md`.
 ### 1. Clarify the Layout Contract
 
 - Identify the active scene or `UIDocument` before editing.
-- Choose the UI stack, change mode, and asset strategy explicitly.
+- Choose the UI stack, change mode, design source, and asset strategy explicitly.
+- If a design-system source exists, extract the tokens, prose intent, component states, and any do/don't guardrails before styling.
 - Inspect the root layout owner before touching children.
 - For UGUI, inspect `Canvas`, `CanvasScaler`, parent `RectTransform`, layout components, and safe-area handling.
 - For UI Toolkit, inspect `UIDocument`, linked `UXML`, linked `USS`, panel settings, and container ownership.
@@ -119,6 +132,8 @@ Do not call the task done until every applicable check below passes:
 - The layout was re-checked at one additional aspect ratio, or portrait plus landscape for mobile-first work.
 - Compile or console errors were cleared if script-backed UI changed.
 - Text behavior still works for longer or more realistic content.
+- Provided design-system tokens and prose were preserved, or deviations were explicitly justified.
+- Component text/background pairs were checked for readable contrast where the source defines both values.
 - Shared-asset edits were treated with explicit safety checks.
 - Low-confidence asset reuse stayed clearly provisional.
 
@@ -131,6 +146,11 @@ Do not call the task done until every applicable check below passes:
 - `references/review-checks.md`
 - `references/scroll-view-patterns.md`
 - `references/ui-change-modes.md`
+
+### Design Systems and Tokens
+
+- `references/design-system-intake.md`
+- `references/design-token-to-unity.md`
 
 ### Mockups, Resolution, and Safe Area
 

--- a/unity-mcp-ui-layout/agents/openai.yaml
+++ b/unity-mcp-ui-layout/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Unity MCP UI Layout"
-  short_description: "Resolution-aware Unity UI layout and repair through MCP for UGUI or UI Toolkit, with safe area, text, reuse, and screenshot verification in scope."
-  default_prompt: "Use $unity-mcp-ui-layout to repair or build Unity UI through staged, layout-focused edits. Choose UGUI or UI Toolkit first, decide repair versus build, keep structure stable across resolutions, and verify with screenshots. Reuse existing assets only when the task clearly requires asset-aware decisions."
+  short_description: "Resolution-aware Unity UI layout and repair through MCP for UGUI or UI Toolkit, with DESIGN.md/token intake, safe area, text, reuse, and screenshot verification in scope."
+  default_prompt: "Use $unity-mcp-ui-layout to repair or build Unity UI through staged, layout-focused edits. Choose UGUI or UI Toolkit first, decide repair versus build, read any DESIGN.md or design-token source before styling, keep structure stable across resolutions, and verify with screenshots. Reuse existing assets only when the task clearly requires asset-aware decisions."

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -27,6 +27,8 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `common-failures.md`
 - `review-checks.md`
 - `scroll-view-patterns.md`
+- `design-system-intake.md`
+- `design-token-to-unity.md`
 
 ## UGUI-Focused Guidance
 

--- a/unity-mcp-ui-layout/references/design-system-intake.md
+++ b/unity-mcp-ui-layout/references/design-system-intake.md
@@ -1,0 +1,103 @@
+# Design System Intake
+
+Use this guide when the user provides a `DESIGN.md`, `design_tokens.json`, Tailwind theme, style guide, or similar design-system source with a Unity UI task.
+
+Pair it with `design-token-to-unity.md` when you need to map tokens into UGUI, TextMeshPro, UI Toolkit, or USS.
+
+## Goal
+
+Use the design-system source as the styling contract while keeping this skill's layout-first workflow intact.
+
+- Tokens provide exact values.
+- Prose explains intent, hierarchy, and judgment calls.
+- Mockups show composition, not permission to ignore tokens.
+
+## Intake Order
+
+1. Identify the source type: `DESIGN.md`, token JSON, Tailwind theme, Figma-exported values, or prose-only style guide.
+2. Extract color, typography, spacing, rounded, component, and state values.
+3. Read prose sections for brand style, color usage, layout philosophy, elevation, shapes, components, and do/don't rules.
+4. Decide whether the task is build mode or repair mode before changing style.
+5. Map the design source into Unity using `design-token-to-unity.md`.
+6. Verify the result with screenshots and a style preservation pass.
+
+## DESIGN.md Specific Rules
+
+For `DESIGN.md` files:
+
+- Read YAML front matter first.
+- Then read Markdown sections for intent.
+- If both are present, treat tokens as normative for concrete values.
+- Use prose to resolve ambiguity such as when to use an accent color, how dense the layout should feel, or whether depth comes from shadows, tonal layers, glass, or borders.
+- Preserve unknown sections as useful context instead of treating them as errors.
+
+Common sections to scan:
+
+- `Overview` or `Brand & Style`
+- `Colors`
+- `Typography`
+- `Layout` or `Layout & Spacing`
+- `Elevation & Depth`
+- `Shapes`
+- `Components`
+- `Do's and Don'ts`
+
+## Optional CLI Preflight
+
+If the `@google/design.md` CLI is available, run the relevant check before implementation:
+
+```bash
+npx @google/design.md lint DESIGN.md
+npx @google/design.md diff DESIGN-before.md DESIGN-after.md
+npx @google/design.md export --format dtcg DESIGN.md
+```
+
+Use the linter output to catch broken references, missing core tokens, contrast problems, section-order issues, and orphaned tokens.
+
+If the CLI is unavailable, continue manually:
+
+- parse the front matter or token file directly
+- note unresolved token references
+- check obvious text/background contrast pairs by inspection or project tooling
+- keep any low-confidence mapping explicit
+
+Missing CLI support is not a blocker for layout work.
+
+## Conflict Rules
+
+When sources disagree:
+
+- Explicit user instruction overrides a design source for the current task.
+- A provided design source overrides ad hoc visual guesses.
+- Tokens override prose for exact values such as colors, font sizes, spacing, and radii.
+- Prose overrides the mockup when the mockup appears to be only illustrative.
+- Existing project UI conventions matter in repair mode; do not restyle unrelated regions just because a token file exists.
+
+## Build Mode
+
+When building a new screen:
+
+- Create a small style inventory before implementation: color roles, text roles, spacing scale, corner scale, and component states.
+- Reuse existing project fonts, TMP styles, USS classes, sprites, or prefabs when they already represent the design source.
+- Create new local styles only when the design role is missing.
+- Keep layout regions, anchors, safe area, scroll ownership, and repeated-item reuse as the primary structure.
+
+## Repair Mode
+
+When repairing an existing screen:
+
+- Compare the current UI against the design source before changing visuals.
+- Fix layout drift without introducing new random colors, fonts, radii, or one-off spacing.
+- If the screen already uses shared styles that match the design source, preserve them.
+- If a shared style appears wrong for the whole product, check another known usage before editing it.
+- If the requested change is local, use a local override, wrapper, or variant instead of rewriting the shared style system.
+
+## Completion Questions
+
+Before calling the work done, ask:
+
+- Did every visible color, text role, corner radius, and repeated component style trace back to the design source or an existing project equivalent?
+- Did prose intent affect hierarchy, density, depth, and interaction feedback?
+- Were text/background pairs readable where both values were known?
+- Did repair work avoid broad style drift outside the requested scope?
+- Were deviations from the design source named instead of hidden?

--- a/unity-mcp-ui-layout/references/design-token-to-unity.md
+++ b/unity-mcp-ui-layout/references/design-token-to-unity.md
@@ -1,0 +1,141 @@
+# Design Token to Unity Mapping
+
+Use this guide after `design-system-intake.md` when a Unity UI task includes concrete design tokens.
+
+The goal is to map design-system values into Unity-owned style assets or classes without weakening layout stability.
+
+## Mapping Summary
+
+| Token group | UGUI / TMP target | UI Toolkit target |
+|---|---|---|
+| `colors` | `Color`, `Image.color`, TMP color, material or style asset | USS custom properties, classes, `color`, `background-color`, border colors |
+| `typography` | TMP font asset, TMP style, font size, weight approximation, line spacing | USS font family, size, weight, line height, letter spacing |
+| `spacing` | LayoutGroup padding/spacing, RectTransform offsets, safe-area margins | USS padding, margin, gap, width constraints |
+| `rounded` | sliced sprites, panel/button art, mask shape, project shape prefab | `border-radius` where supported |
+| `components` | prefab variants, style presets, Selectable states | UXML templates, USS classes, pseudo/state classes |
+
+## Color Tokens
+
+Map semantic roles before applying colors:
+
+- `primary`: main action, dominant highlight, selected state
+- `secondary`: secondary action or supporting interactive color
+- `tertiary`: accent, badge, special state, or domain highlight
+- `surface`, `background`, `neutral`: containers and page foundation
+- `on-*`: text or icon color placed on the matching background
+- `error`: destructive, invalid, or warning states
+
+For UGUI:
+
+- Prefer existing project color style assets when they match.
+- Apply colors through reusable prefabs, TMP styles, or screen-level style helpers instead of scattered one-off overrides.
+- Keep static sprite artwork intact when the color is baked into a project asset and the task is only layout repair.
+
+For UI Toolkit:
+
+- Prefer USS classes or custom properties over inline style writes.
+- Keep repeated component colors in one class family.
+
+Check text/background contrast when component tokens define both `backgroundColor` and `textColor`.
+
+## Typography Tokens
+
+Map typography by role, not by individual label.
+
+Common role mapping:
+
+- display or headline -> screen title, hero value, large HUD number
+- title -> panel title, dialog title, section header
+- body -> descriptions, popup copy, settings explanations
+- label -> buttons, tabs, badges, metadata
+- caption -> helper text, small counters, secondary metadata
+
+For UGUI / TextMeshPro:
+
+- Reuse existing TMP font assets and styles first.
+- Create or select a small number of text roles instead of giving every label unique settings.
+- Map `fontSize`, `fontWeight`, `lineHeight`, and `letterSpacing` where the project stack supports them.
+- Treat unsupported font features or weights as intent to approximate, not as license for random local typography.
+
+For UI Toolkit:
+
+- Put typography roles in USS classes.
+- Keep wrapping, truncation, and overflow explicit for important text roles.
+
+## Spacing Tokens
+
+Use spacing tokens as rhythm, not as raw pixel copying.
+
+- Map base units to LayoutGroup spacing, padding, margins, and region gaps.
+- Use spacing tokens inside stable parent containers after anchor or flex ownership is correct.
+- Do not use token values as many leaf-level offsets to compensate for broken parent structure.
+- Keep safe-area padding separate from decorative spacing unless the design source says otherwise.
+
+## Rounded Tokens
+
+For UGUI:
+
+- Prefer existing sliced sprites or panel prefabs that already express the shape language.
+- If rounded corners are baked into sprites, avoid replacing assets during a layout-only repair.
+- Use variants or wrappers when one screen needs a different radius from the shared base.
+
+For UI Toolkit:
+
+- Map directly to `border-radius` where available.
+- Keep radius classes consistent across buttons, cards, inputs, badges, and modals.
+
+## Component Tokens and States
+
+Treat component tokens as reusable style roles.
+
+Examples:
+
+- `button-primary` -> primary button prefab variant or USS class
+- `button-primary-hover` -> hover/selected/pressed visual state
+- `input-field` -> input prefab, TMP input style, or USS input class
+- `card-profile` -> reusable card prefab or UXML template class
+- `badge-status` -> small reusable badge style
+
+For UGUI:
+
+- Use `Selectable` color transitions, sprite swaps, animation triggers, or prefab variants for states.
+- Keep layout ownership in the parent; keep component styling inside the reusable unit.
+- Avoid copying the same button or card values into many children manually.
+
+For UI Toolkit:
+
+- Use USS class families for base and state styles.
+- Use pseudo-classes or state classes where the project supports them.
+- Keep UXML structure separate from style token values when practical.
+
+## Elevation and Depth
+
+DESIGN.md prose often describes depth more clearly than tokens do.
+
+Map intent conservatively:
+
+- tonal layers -> surface colors and container hierarchy
+- shadows -> project shadow component, material, or subtle sprite treatment
+- glass -> translucent surface, blur-like project effect if available, edge stroke, and clear contrast checks
+- flat design -> borders, spacing, and color contrast instead of invented shadows
+
+Do not add expensive runtime effects just because web prose mentions blur or glass. Use the closest project-supported visual language unless the user asks for a new effect.
+
+## Repair Safety
+
+In repair mode:
+
+- Preserve current style assets that already match the design source.
+- Do not replace a shared font, material, sprite, or prefab base for one local mismatch without checking another usage.
+- Keep emergency text or spacing fixes local unless the token role itself is wrong everywhere.
+- Name any intentional deviation from the design source.
+
+## Review Questions
+
+Ask:
+
+- Are token values mapped through reusable style roles rather than scattered overrides?
+- Did typography preserve roles and text behavior?
+- Did component states survive, not just the default visual state?
+- Did layout still use anchors, containers, flex, and safe-area rules instead of token-sized pixel nudges?
+- Does the final screenshot preserve both the design source and the requested composition?

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -131,7 +131,22 @@ Ask:
 
 This is where hand-placed designs usually reveal themselves.
 
-## 12. Scope Check
+## 12. Design System Check
+
+Use this check when the task included `DESIGN.md`, design tokens, a Tailwind theme, or another design-system source.
+
+Ask:
+
+- Did visible colors, typography, spacing, radius, and component states trace back to the design source or an existing project equivalent?
+- Were token values treated as the concrete style contract and prose treated as intent?
+- Are button, card, input, badge, and list states mapped through reusable styles instead of local one-off values?
+- Were known text/background pairs checked for readable contrast?
+- Did the work avoid introducing style drift outside the requested repair scope?
+- Were any deviations from the design source named and justified?
+
+If the answer is no, revisit the design-source mapping before calling the UI done.
+
+## 13. Scope Check
 
 Ask:
 
@@ -144,7 +159,7 @@ Ask:
 
 If the answer is no, narrow the change before shipping it.
 
-## 13. Final Go/No-Go Rule
+## 14. Final Go/No-Go Rule
 
 Do not call the UI complete unless:
 
@@ -153,3 +168,4 @@ Do not call the UI complete unless:
 3. no obvious clipping or overlap remains
 4. safe area ownership is correct where relevant
 5. the structure does not depend on arbitrary pixel corrections
+6. any provided design-system source is still respected where applicable


### PR DESCRIPTION
## Summary
- Add DESIGN.md/design-token intake routing to the Unity MCP UI Layout skill
- Add references for design-system intake and token-to-Unity mapping
- Add copyable DESIGN.md build/repair examples and update navigation/platform adapters

## Validation
- `python3 /Users/song/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/song/Projects/unity-mcp-ui-layout/unity-mcp-ui-layout` -> `Skill is valid!`
- `git diff --check` -> passed

Closes #48