### PR TITLE
[codex] Strengthen mockup layer tree decomposition

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -24,6 +24,7 @@ Global Codex skill path:
 robocopy D:\UnityUICreater\unity-mcp-ui-layout C:\Users\user\.codex\skills\unity-mcp-ui-layout /MIR
 python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.py D:\UnityUICreater\unity-mcp-ui-layout
 bash D:/UnityUICreater/tests/trigger_keywords.sh
+bash D:/UnityUICreater/tests/layer_tree_keywords.sh
 python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.py C:\Users\user\.codex\skills\unity-mcp-ui-layout
 ```
 
@@ -62,12 +63,14 @@ flowchart TD
 
 - frontmatter is still valid and readable
 - trigger keyword checks still cover mockup/image-to-prefab request wording
+- layer/tree keyword checks still cover mockup-to-Transform hierarchy wording
 - new rules are linked from the right navigation points
 - examples reinforce the rules instead of contradicting them
 - no new file silently became the only source of important guidance
 
 - frontmatter가 여전히 정상 파싱되는지 확인합니다.
 - mockup/image-to-prefab 요청 표현을 trigger keyword check가 계속 커버하는지 확인합니다.
+- mockup-to-Transform hierarchy 표현을 layer/tree keyword check가 계속 커버하는지 확인합니다.
 - 새 규칙이 올바른 진입점에서 연결되는지 확인합니다.
 - examples가 규칙을 강화하는지, 모순되지 않는지 확인합니다.
 - 중요한 규칙이 새 파일 한 곳에만 숨어버리지 않았는지 확인합니다.

--- a/Platform/Codex/README.md
+++ b/Platform/Codex/README.md
@@ -87,6 +87,7 @@ Flag missing assets, unresolved variables, or unsupported node types before fina
 ```text
 Use $unity-mcp-ui-layout to build a 1920x1080 UGUI HUD from the attached layout image.
 Group the top-level composition into anchor-owned regions first.
+Analyze the visual layers -> clean Unity Transform/RectTransform tree before creating objects.
 Translate the image into anchors, parent containers, and CanvasScaler rules.
 Turn repeated structures into reusable prefabs or reusable layout blocks.
 Keep likely single-image regions intact unless runtime behavior requires them to be split.
@@ -96,6 +97,7 @@ Verify the result with screenshots instead of raw pixel placement.
 ```text
 $unity-mcp-ui-layout를 사용해서 첨부한 레이아웃 이미지를 기준으로 1920x1080 UGUI HUD를 만들어줘.
 먼저 top-level 구성을 anchor 기준 영역으로 나눠줘.
+오브젝트를 만들기 전에 visual layers -> clean Unity Transform/RectTransform tree로 레이어/트리 구조를 먼저 분석해줘.
 이미지를 anchors, parent containers, CanvasScaler 규칙으로 변환해줘.
 반복 구조는 reusable prefab 또는 reusable layout block으로 만들어줘.
 단일 이미지로 보이는 영역은 런타임 동작상 분리가 필요할 때만 나눠줘.
@@ -105,6 +107,7 @@ raw pixel 배치 대신 스크린샷으로 검증해줘.
 ```text
 I attached a Unity UI mockup from the current project.
 Create Unity UI prefabs from this design screenshot, using UGUI unless the project already uses UI Toolkit.
+Analyze visual layers into a clean Unity Transform/RectTransform tree before creating prefab assets.
 Group the screen into anchor-owned parent regions first, then make repeated blocks reusable.
 ```
 

--- a/Platform/README.md
+++ b/Platform/README.md
@@ -25,6 +25,7 @@ Each adapter keeps the same core rules:
 
 - prefer anchors and containers over raw pixels
 - group the top-level composition by anchor-owned regions before leaf-level tuning
+- analyze mockups as visual layers -> clean Unity Transform/RectTransform tree before object creation
 - choose scaling rules before sizing children
 - reuse repeated structures through prefabs or reusable blocks where appropriate
 - treat Stitch HTML/CSS and Figma node-tree exports as hierarchy sources when provided
@@ -36,6 +37,7 @@ Each adapter keeps the same core rules:
 
 - raw pixel보다 anchors와 containers를 우선합니다
 - leaf-level 조정보다 먼저 top-level 구성을 anchor 기준 영역으로 나눕니다
+- 목업이나 UI 시안은 오브젝트 생성 전에 visual layers -> clean Unity Transform/RectTransform tree로 레이어/트리 구조를 먼저 분석합니다
 - 자식 크기를 만지기 전에 scaling 규칙을 먼저 정합니다
 - 반복 구조는 상황에 맞게 prefab 또는 reusable block으로 재사용합니다
 - Stitch HTML/CSS와 Figma node-tree export가 제공되면 hierarchy source로 다룹니다

--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ Codex는 "첨부한 UI 시안을 기준으로 Unity UI를 만들어줘" 또는 "
 ## Quick Rules / 빠른 작업 기준
 
 - Group the top-level layout by anchor-owned regions before tuning leaf widgets.
+- When a mockup or UI 시안 exists, analyze visual layers -> clean Unity Transform/RectTransform tree before creating objects.
 - Turn repeated UI structures into reusable prefabs or reusable layout blocks.
 - Keep likely single-image regions intact unless interaction, animation, or adaptive behavior requires decomposition.
 - Verify structure with screenshots instead of chasing raw pixel alignment.
 
 - leaf widget를 만지기 전에 최상단 레이아웃을 먼저 anchor 기준 영역으로 그룹화합니다.
+- UI 시안이나 목업이 있으면 오브젝트 생성 전에 visual layers -> clean Unity Transform/RectTransform tree로 레이어/트리 구조를 먼저 분석합니다.
 - 반복되는 UI 구조는 재사용 가능한 프리팹 또는 레이아웃 블록으로 만듭니다.
 - 단일 이미지 리소스로 보이는 영역은 상호작용, 애니메이션, 적응형 동작이 필요할 때만 분해합니다.
 - raw pixel 정렬을 쫓기보다 스크린샷으로 구조를 검증합니다.
@@ -254,6 +256,7 @@ cp -R ./unity-mcp-ui-layout ~/.codex/skills/
 
 ```text
 Use $unity-mcp-ui-layout to build a 1920x1080 UGUI HUD from the attached layout image.
+Analyze the visual layers -> clean Unity Transform/RectTransform tree before creating objects.
 Group the top-level composition into anchor-owned regions, then translate it into parent containers and CanvasScaler rules.
 Turn repeated structures into reusable prefabs or reusable layout blocks.
 If a region looks like a single image resource, keep it as one image unless runtime behavior requires it to be split.
@@ -262,6 +265,7 @@ Verify the result with screenshots instead of relying on raw pixel placement.
 
 ```text
 $unity-mcp-ui-layout를 사용해서 첨부한 레이아웃 이미지를 기준으로 1920x1080 UGUI HUD를 만들어줘.
+오브젝트를 만들기 전에 visual layers -> clean Unity Transform/RectTransform tree로 레이어/트리 구조를 먼저 분석해줘.
 최상단 구성을 먼저 anchor 기준 영역으로 그룹화한 뒤 부모 컨테이너와 CanvasScaler 규칙으로 변환해줘.
 반복 구조는 재사용 가능한 프리팹 또는 레이아웃 블록으로 만들어줘.
 단일 이미지 리소스로 보이는 영역은 런타임 동작상 분리가 필요할 때만 나눠줘.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -30,12 +30,14 @@ Use this checklist when preparing a tagged release for this repository.
 
 - validate the repo skill
 - run trigger keyword checks when discoverability or skill activation wording changed
+- run layer/tree keyword checks when mockup decomposition or hierarchy guidance changed
 - if you use the global skill for local testing, sync it once and validate again
 - quickly read the changed entry points as if you were a first-time user
 - make sure new examples still match the actual rules
 
 - 저장소 안의 정본 스킬을 검증합니다.
 - discoverability나 스킬 작동 트리거 문구가 바뀌었다면 trigger keyword check를 실행합니다.
+- mockup decomposition이나 hierarchy 지침이 바뀌었다면 layer/tree keyword check를 실행합니다.
 - 전역 스킬로도 테스트한다면 한 번 동기화한 뒤 다시 검증합니다.
 - 처음 보는 사용자라고 가정하고 바뀐 진입 문서를 빠르게 다시 읽습니다.
 - 새 examples가 실제 규칙과 어긋나지 않는지 확인합니다.
@@ -45,6 +47,7 @@ Use this checklist when preparing a tagged release for this repository.
 ```powershell
 python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.py D:\UnityUICreater\unity-mcp-ui-layout
 bash D:/UnityUICreater/tests/trigger_keywords.sh
+bash D:/UnityUICreater/tests/layer_tree_keywords.sh
 robocopy D:\UnityUICreater\unity-mcp-ui-layout C:\Users\user\.codex\skills\unity-mcp-ui-layout /MIR
 python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.py C:\Users\user\.codex\skills\unity-mcp-ui-layout
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Use these files when you want a copyable starting point instead of only referenc
 ## Quick Rules
 
 - Group the top-level layout by anchor-owned regions before tuning leaf widgets.
+- When a mockup exists, run a layer-to-tree pass before object creation so the Unity Transform tree follows the visual layer structure.
 - Read provided `DESIGN.md` or design-token sources before styling.
 - Reuse repeated structures through prefabs or reusable layout blocks.
 - Keep likely single-image regions intact unless runtime behavior requires decomposition.
@@ -63,6 +64,7 @@ Use these files when you want a copyable starting point instead of only referenc
 - Start with `mockup-resolution-example.md` when the mockup's own pixel resolution should drive planning.
 - Start with `prefab-from-mockup-example.md` when an uploaded mockup screenshot, dropped design image, or UI 시안 should become Unity UI prefabs or reusable blocks.
 - Start with `mockup-decomposition-example.md` when the main question is what should stay baked, what should split, and what should become a reusable block before layout work begins.
+- Use `mockup-decomposition-example.md` for 레이어/트리 구조 work when a UI 시안 should become a cleaner Unity Transform or RectTransform hierarchy.
 - Start with `design-md-layout-example.md` when a new screen should be built from a mockup plus `DESIGN.md` or design-token inputs.
 - Start with `design-md-repair-example.md` when an existing screen should be repaired against `DESIGN.md` without drifting from shared tokens.
 - Start with `stitch-html-to-ugui-example.md` when the hierarchy source is a Stitch HTML/CSS export that should become stable UGUI containers.

--- a/examples/hud-example.md
+++ b/examples/hud-example.md
@@ -11,6 +11,7 @@ The user provides a HUD mockup image and wants a `1920x1080` UGUI implementation
 ```text
 Use $unity-mcp-ui-layout to build a 1920x1080 UGUI HUD from the attached mockup.
 Treat the image as a composition reference, not a raw pixel map.
+Run a layer-to-tree pass before creating objects so the HUD visual layers become a clean Transform/RectTransform hierarchy.
 Group the top-level layout by anchor-owned regions first.
 Create the root canvas structure first, then SafeAreaRoot and HUDRoot, then add corner and center containers before leaf widgets.
 Turn repeated HUD structures into reusable prefabs or reusable layout blocks.
@@ -21,6 +22,7 @@ Verify each structural step with screenshots and re-check one alternate aspect r
 ```text
 $unity-mcp-ui-layout를 사용해서 첨부한 목업으로 1920x1080 UGUI HUD를 만들어줘.
 이미지는 raw pixel map이 아니라 composition reference로 취급해줘.
+오브젝트를 만들기 전에 layer-to-tree pass를 실행해서 HUD 시각 레이어가 깔끔한 Transform/RectTransform hierarchy가 되게 해줘.
 최상단 레이아웃은 먼저 anchor 기준 영역으로 그룹화해줘.
 먼저 root canvas 구조를 만들고, 그다음 SafeAreaRoot와 HUDRoot를 만든 뒤, leaf widget보다 corner와 center container를 먼저 추가해줘.
 반복되는 HUD 구조는 재사용 가능한 프리팹 또는 레이아웃 블록으로 만들어줘.

--- a/examples/mockup-decomposition-example.md
+++ b/examples/mockup-decomposition-example.md
@@ -1,22 +1,23 @@
 # Mockup Decomposition Example
 
-Use this example when a mockup exists and the main risk is splitting visual regions too much, or not splitting runtime-owned parts enough.
+Use this example when a mockup exists and the main risk is splitting visual regions too much, not splitting runtime-owned parts enough, or creating a Unity Transform tree that does not reflect the design layers.
 
 ## Scenario
 
 - A mockup image exists.
 - The UI may contain baked decorative art, repeated cards or rows, and interactive widgets.
-- The task needs a decomposition decision before layout tuning or pixel matching.
+- The task needs a decomposition decision and Transform tree plan before layout tuning or pixel matching.
 
 ## Example Prompt
 
 ```text
 Use $unity-mcp-ui-layout to build this UI from the attached mockup.
-Before creating objects, inspect the mockup and write a decomposition pass:
+Before creating objects, inspect the mockup and write a layer-to-tree pass:
 - top-level anchor-owned regions
 - repeated groups that should become reusable blocks or prefabs
 - runtime-owned widgets that need interaction, dynamic text, state, animation, safe-area behavior, or adaptive layout
 - decorative or baked regions that should stay as one image or sprite region
+- a Transform tree plan, such as Canvas -> SafeAreaRoot -> ScreenRoot -> RegionRoot -> ReusableGroup -> RuntimeLeaf
 
 Decompose by runtime responsibility, not by visual outline alone.
 Keep decorative panels, ornaments, and baked art whole unless runtime behavior requires separation.
@@ -26,9 +27,16 @@ After the decomposition pass, build parent containers before leaf widgets and ke
 Verify that every split has a runtime reason and that no repeated block was rebuilt manually.
 ```
 
+```text
+첨부한 UI 시안을 먼저 레이어/트리 구조로 분석해줘.
+시각 레이어를 background, safe-area owner, major regions, reusable groups, runtime leaves, decorative image layers로 나누고,
+각 레이어가 Unity RectTransform tree에서 어떤 부모/자식 관계가 되는지 제안한 뒤 오브젝트를 만들어줘.
+```
+
 ## Why This Works
 
 - It makes asset granularity a deliberate decision before layout work starts.
+- It forces a Transform tree plan before object creation.
 - It prevents fake child objects that only mirror visual edges in the mockup.
 - It keeps interactive, stateful, and adaptive parts separate from baked art.
 - It promotes repeated structures into reusable blocks instead of one-off copies.
@@ -39,6 +47,8 @@ Verify that every split has a runtime reason and that no repeated block was rebu
 - Did decorative panels, ornaments, and baked art stay whole where possible?
 - Are repeated cards, rows, slots, button groups, or badge clusters represented by one reusable pattern?
 - Are top-level regions grouped before atomic widgets are tuned?
+- Does the layer-to-tree pass produce a readable parent-owned Unity Transform tree?
+- 레이어/트리 구조가 부모 소유권, 반복 그룹, 런타임 leaf를 구분하는가?
 - Would another engineer understand why each region exists at runtime?
 
 ## Suggested References

--- a/examples/mockup-resolution-example.md
+++ b/examples/mockup-resolution-example.md
@@ -15,6 +15,7 @@ This example shows how to work from a design image when the mockup's own pixel r
 Use $unity-mcp-ui-layout to build this UGUI HUD from the attached mockup.
 The mockup image is 1600x900 and the implementation target is 1920x1080.
 Use the mockup resolution as the composition measurement space and 1920x1080 as the implementation and verification space.
+Run a layer-to-tree pass in the mockup resolution before translating the result into a Unity Transform/RectTransform hierarchy.
 Group the top-level composition into anchor-owned regions first.
 Do not decompose decorative baked regions unless runtime behavior requires it.
 Turn repeated status widgets into one reusable prefab or reusable layout block.

--- a/examples/prefab-from-mockup-example.md
+++ b/examples/prefab-from-mockup-example.md
@@ -16,6 +16,7 @@ Use this example when a user uploads, attaches, or drops a Unity UI mockup scree
 I attached a mockup screenshot from the current Unity project.
 Create a Unity UI prefab from this design image.
 Inspect whether the project uses UGUI or UI Toolkit before creating objects.
+Run a layer-to-tree pass so the visual layers become a clean Transform/RectTransform hierarchy before prefab creation.
 Group the top-level screen into anchor-owned parent regions first.
 Turn repeated cards, slots, buttons, or rows into reusable prefabs or reusable layout blocks.
 Keep decorative baked regions as single image assets unless runtime behavior requires splitting.
@@ -26,6 +27,7 @@ Verify the created prefab instance with a screenshot.
 현재 Unity 프로젝트의 UI 시안을 첨부했어.
 이 시안 이미지로 Unity UI 프리팹 만들어줘.
 먼저 프로젝트가 UGUI인지 UI Toolkit인지 확인해줘.
+프리팹을 만들기 전에 layer-to-tree pass를 실행해서 시각 레이어가 깔끔한 Transform/RectTransform hierarchy가 되게 해줘.
 화면을 anchor 기준 부모 영역으로 나눈 다음, 반복되는 카드/슬롯/버튼/행은 재사용 가능한 프리팹이나 레이아웃 블록으로 만들어줘.
 장식용으로 구워진 영역은 런타임 동작상 분리가 필요할 때만 나눠줘.
 생성한 프리팹 인스턴스를 스크린샷으로 검증해줘.

--- a/tests/layer_tree_keywords.sh
+++ b/tests/layer_tree_keywords.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+skill_surface="$(sed -n '1,4p' "$ROOT_DIR/unity-mcp-ui-layout/SKILL.md"; printf '\n'; cat "$ROOT_DIR/unity-mcp-ui-layout/agents/openai.yaml")"
+skill_body="$(cat "$ROOT_DIR/unity-mcp-ui-layout/SKILL.md")"
+image_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/image-to-layout.md")"
+mockup_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/mockup-decomposition.md")"
+review_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/review-checks.md")"
+prompt_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/prompt-patterns.md")"
+mcp_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/mcp-call-recipes.md")"
+ugui_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/ugui-anchors-canvas-scaler.md")"
+stitch_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/stitch-html-to-ugui.md")"
+figma_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/figma-node-tree-to-ugui.md")"
+references_index="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/README.md")"
+entry_docs="$(cat "$ROOT_DIR/README.md"; printf '\n'; cat "$ROOT_DIR/Platform/README.md"; printf '\n'; cat "$ROOT_DIR/Platform/Codex/README.md")"
+examples_docs="$(cat "$ROOT_DIR/examples/README.md"; printf '\n'; cat "$ROOT_DIR/examples/mockup-decomposition-example.md")"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local scope="$3"
+
+  if ! grep -Fqi "$needle" <<<"$haystack"; then
+    printf 'Missing layer/tree phrase in %s: %s\n' "$scope" "$needle" >&2
+    return 1
+  fi
+}
+
+assert_contains "$skill_surface" "layer-to-Transform tree" "skill metadata"
+assert_contains "$skill_surface" "레이어" "skill metadata"
+assert_contains "$skill_surface" "트리 구조" "skill metadata"
+
+assert_contains "$skill_body" "If no structured hierarchy source exists" "skill body"
+assert_contains "$skill_body" "composition validation" "skill body"
+
+assert_contains "$image_doc" "layer pass" "image-to-layout"
+assert_contains "$image_doc" "Unity Transform tree" "image-to-layout"
+assert_contains "$image_doc" "RectTransform tree" "image-to-layout"
+assert_contains "$image_doc" "Tree plan schema" "image-to-layout"
+assert_contains "$image_doc" "node path" "image-to-layout"
+assert_contains "$image_doc" "anchor/pivot intent" "image-to-layout"
+
+assert_contains "$mockup_doc" "layer stack" "mockup-decomposition"
+assert_contains "$mockup_doc" "parent-owned transform hierarchy" "mockup-decomposition"
+assert_contains "$mockup_doc" "draw order" "mockup-decomposition"
+assert_contains "$mockup_doc" "containment" "mockup-decomposition"
+assert_contains "$mockup_doc" "overlay depth" "mockup-decomposition"
+assert_contains "$mockup_doc" "레이어 구조" "mockup-decomposition"
+
+assert_contains "$review_doc" "Layer And Transform Tree Check" "review-checks"
+assert_contains "$prompt_doc" "layer-to-Transform tree pass" "prompt-patterns"
+assert_contains "$prompt_doc" "layer-to-RectTransform tree pass" "prompt-patterns"
+assert_contains "$mcp_doc" "layer-to-RectTransform tree plan" "mcp-call-recipes"
+assert_contains "$ugui_doc" "UGUI realization" "ugui-anchors"
+assert_contains "$stitch_doc" "composition validation" "stitch-html"
+assert_contains "$figma_doc" "composition validation" "figma-node-tree"
+assert_contains "$references_index" "layer-to-tree" "references index"
+
+assert_contains "$entry_docs" "visual layers -> clean Unity Transform/RectTransform tree" "entry docs"
+assert_contains "$examples_docs" "layer-to-tree pass" "examples docs"
+assert_contains "$examples_docs" "Transform tree plan" "examples docs"
+assert_contains "$examples_docs" "레이어/트리 구조" "examples docs"

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unity-mcp-ui-layout
-description: "Use when Unity UI needs layout-focused repair or implementation through `unity-mcp`: attached UI mockup, mockup screenshot, uploaded/dropped design image, reference image, wireframe, or UI 시안 to turn or convert into runtime UGUI/UI Toolkit; create Unity UI prefabs/프리팹 생성, prefab variants, or reusable blocks; or fix cross-resolution drift, safe-area problems, text overflow, structured exports, design tokens, or shared prefab reuse."
+description: "Use when Unity UI needs layout-focused implementation or repair through `unity-mcp`: attached UI mockup, mockup screenshot, uploaded design image, dropped design image, reference image, wireframe, or UI 시안; analyze visual layers into a layer-to-Transform tree/레이어 트리 구조; turn or convert into UGUI/UI Toolkit; create Unity UI prefabs/프리팹 생성; or fix drift, safe area, text overflow, structured exports, tokens, or shared prefab reuse."
 ---
 
 # Unity MCP UI Layout
@@ -16,6 +16,7 @@ Use this skill for Unity UI work where layout stability matters more than raw pi
 - A mockup, screenshot, or wireframe needs to become runtime Unity UI.
 - An attached UI mockup, layout image, mockup screenshot, uploaded or dropped design/reference image, or UI 시안 should become UGUI, UI Toolkit, or Unity UI prefabs.
 - Natural wording such as "turn this reference image into UI", "convert this mockup to a prefab", "시안 던져줄게", or "프리팹 만들어줘" should trigger this skill.
+- A visual design needs a layer-to-Transform tree pass so the Unity Transform or RectTransform hierarchy is planned before object creation.
 - The user asks to create Unity UI prefabs, 프리팹, prefab variants, or reusable UI blocks from a provided design image.
 - An existing UGUI screen drifts across aspect ratios or target resolutions.
 - A UI Toolkit screen looks correct once but breaks after width, overflow, or text changes.
@@ -100,6 +101,8 @@ For structured export intake and hierarchy mapping, read `references/stitch-html
 - Choose the UI stack, change mode, design source, and asset strategy explicitly.
 - If a structured export source exists, normalize it into a semantic tree before copying any coordinates.
 - If a design-system source exists, extract the tokens, prose intent, component states, and any do/don't guardrails before styling.
+- If no structured hierarchy source exists and a mockup, screenshot, reference image, or UI 시안 exists, run a layer-to-Transform tree pass before creating objects and keep that tree as the layout contract.
+- If a structured export and a mockup/screenshot both exist, let the structured export own hierarchy and use the raster layer pass as composition validation.
 - Inspect the root layout owner before touching children.
 - For UGUI, inspect `Canvas`, `CanvasScaler`, parent `RectTransform`, layout components, and safe-area handling.
 - For UI Toolkit, inspect `UIDocument`, linked `UXML`, linked `USS`, panel settings, and container ownership.
@@ -145,6 +148,8 @@ Do not call the task done until every applicable check below passes:
 
 - A fresh whole-screen verification screenshot exists.
 - If a mockup, screenshot, or wireframe was provided, one final review pass was run against it after implementation changes.
+- If no structured hierarchy source existed and a mockup, screenshot, reference image, or UI 시안 drove the work, the final Unity Transform or RectTransform tree still matches the approved layer-to-tree pass.
+- If a structured export existed alongside a mockup/screenshot, hierarchy still follows the export and the raster image was used for composition validation.
 - The layout was re-checked at one additional aspect ratio, or portrait plus landscape for mobile-first work.
 - Compile or console errors were cleared if script-backed UI changed.
 - Text behavior still works for longer or more realistic content.

--- a/unity-mcp-ui-layout/agents/openai.yaml
+++ b/unity-mcp-ui-layout/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Unity MCP UI Layout"
-  short_description: "Unity UI mockup-to-prefab layout via MCP."
-  default_prompt: "Use $unity-mcp-ui-layout to repair or build Unity UI through staged, layout-focused edits. Trigger it for attached UI mockups, mockup screenshots, uploaded design images, dropped design images, reference images, UI 시안, and requests to turn, convert, make, generate, or create Unity UI prefabs or 프리팹 from a design. Include Korean shorthand such as 시안 던져줄게, 시안 보고 만들어줘, and 프리팹 만들어줘. Choose UGUI or UI Toolkit first, decide repair versus build, read DESIGN.md or design tokens before styling, and verify with screenshots."
+  short_description: "Unity UI layer-to-Transform layout via MCP."
+  default_prompt: "Use $unity-mcp-ui-layout to repair or build Unity UI through staged, layout-focused edits. Trigger it for attached UI mockups, mockup screenshots, uploaded design images, dropped design images, reference images, UI 시안, 시안 던져줄게, and requests to turn, convert, make, generate, or create Unity UI prefabs or 프리팹 from a design. For designs, run a layer-to-Transform tree pass first: identify 레이어 구조, 트리 구조, parent-owned regions, reusable groups, runtime leaves, and decorative image layers before creating objects. Choose UGUI or UI Toolkit, read design tokens before styling, and verify with screenshots."

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -7,9 +7,9 @@ Use it when `SKILL.md` points you here for deeper guidance.
 ## Core Guidance
 
 - `layout-checklist.md`
-- `image-to-layout.md` - includes the asset-RAG fallback contract for when `unity-resource-rag` is unavailable or low-confidence.
+- `image-to-layout.md` - includes mockup-to-layer-to-tree workflow and the asset-RAG fallback contract for when `unity-resource-rag` is unavailable or low-confidence.
 - `mcp-call-recipes.md`
-- `mockup-decomposition.md`
+- `mockup-decomposition.md` - owns layer-to-tree decomposition, parent ownership, and split/keep decisions for raster mockups.
 - `mockup-resolution.md`
 - `ui-change-modes.md`
 - `asset-discovery-priority.md`

--- a/unity-mcp-ui-layout/references/figma-node-tree-to-ugui.md
+++ b/unity-mcp-ui-layout/references/figma-node-tree-to-ugui.md
@@ -18,6 +18,7 @@ Convert exported Figma structure into a Unity hierarchy that is:
 - API access to Figma is not available or not allowed.
 
 Do not use this guide for tasks with only an image mockup and no structured node data.
+If a Figma export and screenshot both exist, use the export as the hierarchy source and the screenshot or mockup layer pass as composition validation.
 
 ## Intake Rules
 

--- a/unity-mcp-ui-layout/references/image-to-layout.md
+++ b/unity-mcp-ui-layout/references/image-to-layout.md
@@ -49,20 +49,44 @@ When image-to-layout work intersects with asset reuse, keep the layout workflow 
 
 ## Translation Procedure
 
-### 1. Segment the image
+### 1. Run a layer pass
+
+Before creating Unity objects, describe the layer stack from broad to narrow:
+
+- screen/background layer
+- safe-area or modal ownership layer
+- major region layer such as header, body, footer, side rail, popup, or overlay
+- repeated group layer such as cards, slots, rows, tabs, badges, or button clusters
+- runtime leaf layer such as text, button hit targets, dynamic icons, counters, and stateful badges
+- decorative image layer that should stay as one sprite or image where runtime behavior does not need splitting
+
+The layer pass should produce a Unity Transform tree plan, not just a visual checklist. For UGUI, map it to a RectTransform tree such as `Canvas -> SafeAreaRoot -> ScreenRoot -> RegionRoot -> ReusableGroup -> RuntimeLeaf`. For UI Toolkit, map it to nested `VisualElement` containers with the same ownership boundaries.
+
+Tree plan schema:
+
+- node path: stable path from the screen root, such as `Canvas/HUDRoot/TopRightCluster/CurrencyChip`
+- role: shell, safe-area owner, region, scroll owner, overlay, reusable group, runtime leaf, or decorative image
+- parent owner: the parent that controls position, scaling, spacing, clipping, or safe area
+- Unity type: `Transform`, `RectTransform`, prefab root, layout group, `ScrollRect`, or UI Toolkit `VisualElement`
+- anchor/pivot intent: top-left, stretch, centered, fixed overlay, scroll content, or parent-flow child
+- layout owner: parent layout group, child `LayoutElement`, manual exception, flex container, or USS class
+- geometry ratios: approximate normalized bounds for parent-owned regions before child offsets
+- split/keep reason: runtime behavior, dynamic data, state, animation, reuse, baked art, or decoration
+
+### 2. Segment the image
 
 Break the layout into:
 
 - Root frame
 - Major regions
 - Repeated groups
-- Atomic widgets
+- Runtime leaves only after runtime responsibility is proven
 
 Do not jump directly from whole image to dozens of leaf nodes.
 Group the topmost composition by anchor-owned regions first so the largest blocks already belong to stable screen relationships.
 Split only when runtime behavior requires it, and keep likely decorative baked regions whole.
 
-### 2. Estimate normalized geometry
+### 3. Estimate normalized geometry
 
 For each major element, estimate:
 
@@ -74,7 +98,7 @@ For each major element, estimate:
 Treat these as planning values, not necessarily as final serialized numbers.
 When a mockup image exists, derive them from the mockup's own width and height before mapping them to the implementation frame.
 
-### 3. Pick anchor strategy by region
+### 4. Pick anchor strategy by region
 
 Use these defaults:
 
@@ -86,7 +110,7 @@ Use these defaults:
 
 Anchor according to the element's relationship to the screen, not according to whichever raw coordinates are easiest to enter.
 
-### 4. Build parent containers first
+### 5. Build parent containers first
 
 Create the parent zones before children:
 
@@ -97,7 +121,7 @@ Create the parent zones before children:
 Once the parent is right, many child values become smaller and more stable.
 If the same structure appears multiple times, make one reusable prefab or reusable block before placing all copies.
 
-### 5. Respect single-image regions
+### 6. Respect single-image regions
 
 If a visual area appears to be one baked image or sprite:
 
@@ -105,7 +129,7 @@ If a visual area appears to be one baked image or sprite:
 - Do not force decorative shapes into separate widgets just to trace the mockup more literally.
 - Only split the image when interaction, dynamic text, or adaptive layout requires it.
 
-### 6. Convert proportions into concrete values
+### 7. Convert proportions into concrete values
 
 For a given target resolution:
 
@@ -141,6 +165,7 @@ Prefer "anchored top-right with 4% inset" over "x=1798, y=54".
 Before calling the result correct, verify:
 
 - Does the composition match the image at the target resolution?
+- Did the layer pass produce a clear parent-owned transform hierarchy before object creation?
 - If the mockup had a native resolution, was that resolution captured and used correctly as the planning frame?
 - Are the top-level regions grouped by stable anchor ownership before child tuning?
 - Are anchors consistent with the element's visual role?

--- a/unity-mcp-ui-layout/references/mcp-call-recipes.md
+++ b/unity-mcp-ui-layout/references/mcp-call-recipes.md
@@ -36,16 +36,18 @@ Use this when the user provides a mockup or screenshot and wants a HUD built in 
 ### Typical sequence
 
 1. Inspect the existing scene and UI roots
-2. Create or identify the root canvas structure
-3. Build `SafeAreaRoot` and `HUDRoot`
-4. Add corner and center containers
-5. Add one HUD group at a time
-6. Capture screenshots after each slice
+2. Produce and review a layer-to-RectTransform tree plan before creating objects
+3. Create or identify the root canvas structure
+4. Build `SafeAreaRoot` and `HUDRoot`
+5. Add corner and center containers
+6. Add one HUD group at a time
+7. Capture screenshots after each slice
 
 ### Example prompt
 
 ```text
 Build a 1920x1080 UGUI HUD from the attached image.
+Before creating objects, produce a layer-to-RectTransform tree plan from the mockup.
 Create the root canvas structure first, then SafeAreaRoot and HUDRoot, then add corner containers before leaf widgets.
 Verify each structural step with screenshots.
 ```

--- a/unity-mcp-ui-layout/references/mockup-decomposition.md
+++ b/unity-mcp-ui-layout/references/mockup-decomposition.md
@@ -6,6 +6,33 @@ Use this guide when a mockup, screenshot, design image, or UI 시안 exists and 
 
 Decompose the mockup only as far as runtime behavior needs. Keep the hierarchy honest, avoid fake widget explosion, and preserve reusable structure where the design clearly repeats.
 
+## Layer-To-Transform Tree Contract
+
+Every mockup decomposition should end with a parent-owned transform hierarchy, not only a list of visual parts.
+
+For each layer in the layer stack, name:
+
+- role: background, safe-area owner, region, repeated group, runtime leaf, or decorative image layer
+- owner: which parent controls position, scale, spacing, scroll, clipping, and safe area
+- Unity node: the intended `Transform`, `RectTransform`, prefab root, or UI Toolkit `VisualElement`
+- split reason: interaction, dynamic data, state, animation, localization, adaptive layout, or reuse
+- keep-whole reason: baked art, decoration, no independent runtime behavior, or asset reuse
+
+Infer candidate layers in raster-only mockups from containment, alignment, repeated shapes, shared baselines, shadows or panels, text/icon clusters, and obvious overlay depth.
+
+Use this ordering for a Unity Transform tree or RectTransform tree:
+
+1. screen shell and safe-area owner
+2. major parent-owned regions
+3. scroll, overlay, modal, or fixed-chrome owners
+4. reusable repeated groups or prefab roots
+5. runtime leaves
+6. decorative leaves that stay whole
+
+If a proposed child cannot name its parent ownership or runtime reason, keep it inside the nearest existing layer instead of creating a new node.
+
+Draw order is not the same as parent hierarchy. A background may draw behind a region while living as the first child of that region; an overlay may draw above the screen while still belonging under a modal or overlay root. Preserve draw order through sibling order, canvas sorting, or z-order rules only after the parent-owned transform hierarchy is clear.
+
 ## Core Rule
 
 Decompose by runtime responsibility, not by visual outline alone.
@@ -56,9 +83,10 @@ flowchart TD
 Prefer this order:
 
 1. screen-level anchor-owned regions
-2. reusable repeated blocks
-3. unique interactive elements
-4. decorative single-image regions
+2. parent-owned transform hierarchy
+3. reusable repeated blocks
+4. unique interactive elements
+5. decorative single-image regions
 
 Do not start by tracing every visible edge in the mockup into a separate node.
 
@@ -82,5 +110,7 @@ Do not start by tracing every visible edge in the mockup into a separate node.
 - Which regions are decorative only, and should remain whole?
 - Which regions need runtime ownership and must be split?
 - Which repeated structures should become reusable prefabs or layout blocks?
+- Does the layer stack become a readable Unity Transform tree or RectTransform tree?
+- Are 레이어 구조 and 트리 구조 aligned with parent ownership rather than visual outline alone?
 - Did we decompose based on behavior and layout needs, not just visual outlines?
 - Would another engineer understand why each region exists at runtime?

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -70,7 +70,7 @@ Use when the user provides a mockup or screenshot and target resolution.
 
 ```text
 Use the attached layout image as the composition reference and [WIDTHxHEIGHT] as the reference resolution.
-Before creating objects, identify the major UI regions, group the top-level composition by anchor ownership, and estimate each region's normalized position and size.
+Before creating objects, run a layer-to-Transform tree pass, identify the major UI regions, group the top-level composition by anchor ownership, and estimate each region's normalized position and size.
 Create the parent containers and anchors first.
 If the same structure repeats, make one reusable prefab or reusable layout block before placing all copies.
 If a region looks like a single image resource, keep it as one image unless runtime behavior requires it to be split.
@@ -87,7 +87,7 @@ Use when the user uploads or drops a mockup screenshot, design image, reference 
 
 ```text
 Use the uploaded mockup screenshot as the composition reference.
-Before creating prefab assets, identify the target UI stack, the top-level anchor-owned regions, and the repeated structures that should become reusable prefabs or layout blocks.
+Before creating prefab assets, produce a layer-to-RectTransform tree pass, identify the target UI stack, the top-level anchor-owned regions, and the repeated structures that should become reusable prefabs or layout blocks.
 Create parent containers before leaf widgets, keep decorative baked regions whole unless runtime behavior requires splitting, and verify the prefab instance with a screenshot.
 ```
 

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -43,6 +43,8 @@ If only one resolution works, the implementation is not done yet.
 Ask:
 
 - Does each region have a clear parent that owns layout?
+- Is there a clear layer stack from screen shell to regions, repeated groups, runtime leaves, and decorative image layers?
+- Does the Unity Transform tree or RectTransform tree match that layer stack instead of a flat set of visual fragments?
 - Does each repeated group have a clear layout owner?
 - Were repeated structures turned into reusable prefabs or reusable layout blocks where appropriate?
 - Are child offsets being used only for local adjustments rather than structural compensation?
@@ -50,6 +52,21 @@ Ask:
 - If this is a scroll-heavy UI, is there one clear scroll owner, one content container, and one reusable repeated-item pattern?
 
 If many children carry unique offsets, the structure is probably still too fragile.
+
+## 4A. Layer And Transform Tree Check
+
+Use this check when a mockup, screenshot, reference image, or UI 시안 drove the implementation.
+
+Ask:
+
+- Was a layer pass done before object creation?
+- Does every layer name its parent owner, runtime responsibility, and keep-whole or split reason?
+- Are major visual layers mapped to a parent-owned transform hierarchy rather than copied as unrelated siblings?
+- Are reusable groups represented by prefab roots or reusable layout block roots?
+- Are decorative image layers kept as single image nodes unless interaction, animation, dynamic content, or adaptive layout requires splitting?
+- 레이어 구조 and 트리 구조가 Unity `Transform`/`RectTransform` hierarchy에서 읽히는가?
+
+If the transform tree cannot be read without opening every leaf, return to decomposition before polishing visuals.
 
 ## 5. Asset Granularity Check
 

--- a/unity-mcp-ui-layout/references/stitch-html-to-ugui.md
+++ b/unity-mcp-ui-layout/references/stitch-html-to-ugui.md
@@ -39,6 +39,8 @@ Convert exported structure into runtime-holdable UGUI containers first, then sty
 
 If required files are missing, request missing inputs instead of guessing hierarchy from partial CSS.
 
+If a structured export and screenshot both exist, use the export as the hierarchy source and the screenshot or mockup layer pass as composition validation. Do not let raster layer guesses override clear DOM structure, but use the image to catch missing overlays, baked art, or visual grouping that the export hides.
+
 ## Mapping DOM-Like Hierarchy to UGUI Containers
 
 Use this ownership-first mapping:
@@ -177,4 +179,3 @@ Only apply when target includes mobile displays that need cutout handling:
 - Are text and image roles explicit and stable at runtime?
 - Is safe area handled at one correct parent (where needed)?
 - Did we flag unsupported CSS or unclear intent instead of silently guessing?
-

--- a/unity-mcp-ui-layout/references/ugui-anchors-canvas-scaler.md
+++ b/unity-mcp-ui-layout/references/ugui-anchors-canvas-scaler.md
@@ -45,13 +45,16 @@ Do not leave the choice implicit. State why the match setting was chosen.
 
 ## 2. Container Hierarchy Rules
 
-Build UGUI in layers:
+Build UGUI in layers. This is the UGUI realization of the `image-to-layout.md` layer pass:
 
 1. `Canvas`
 2. Safe-area root if needed
-3. Major screen regions such as header, footer, left rail, right rail, content, modal root
-4. Local groups such as rows, columns, grids
-5. Leaf widgets
+3. Screen root or modal/overlay root
+4. Major screen regions such as header, footer, left rail, right rail, content, modal root
+5. Scroll owners and content roots where applicable
+6. Reusable prefab roots or repeated layout block roots
+7. Local groups such as rows, columns, grids
+8. Runtime leaves and decorative image leaves
 
 Prefer a stable parent container over repeatedly calculating child offsets against the full screen.
 


### PR DESCRIPTION
## Summary
- Strengthens skill entry points so mockup/reference image/UI 시안 requests trigger a layer-to-Transform/RectTransform tree pass before object creation.
- Adds a tree plan schema, raster layer heuristics, and review gates so decomposed layers map to a cleaner Unity hierarchy instead of flat or fake-child structures.
- Preserves structured export precedence: Figma/Stitch hierarchy remains the source of truth, while raster screenshots are used for composition validation.
- Updates examples/platform docs and adds `tests/layer_tree_keywords.sh`.

## Root Cause
Existing guidance emphasized grouping and avoiding over-decomposition, but did not require an explicit visual layer analysis and hierarchy plan before MCP object creation. That made mockup-driven prefab requests easier to interpret as surface-level grouping rather than a clean parent-owned Transform tree.

## Validation
- [x] `bash -n tests/layer_tree_keywords.sh && bash tests/layer_tree_keywords.sh`
- [x] `bash -n tests/trigger_keywords.sh && bash tests/trigger_keywords.sh`
- [x] `python /Users/song/.codex/skills/.system/skill-creator/scripts/quick_validate.py unity-mcp-ui-layout`
- [x] `ruby -e 'require "yaml"; YAML.load_file("unity-mcp-ui-layout/agents/openai.yaml"); puts "ok"'`
- [x] `git diff --check HEAD`

Closes #60