### PR TITLE
[codex] Prepare v0.6.0 release docs

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,8 +1,8 @@
 # Backlog
 
-This backlog tracks likely next improvements for the repository after `v0.4.1`.
+This backlog tracks likely next improvements for the repository after `v0.6.0`.
 
-이 backlog는 `v0.4.1` 이후, 다음에 다듬을 만한 항목을 정리합니다.
+이 backlog는 `v0.6.0` 이후, 다음에 다듬을 만한 항목을 정리합니다.
 
 ## High Priority / 높은 우선순위
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,31 @@ This project follows a lightweight documentation-focused release flow.
 
 ## Unreleased
 
+No changes yet.
+
+## v0.6.0 - 2026-06-26
+
 ### Added
 
+- Added stronger trigger coverage for attached UI mockups, design screenshots, reference images, UI 시안, and Unity UI prefab or 프리팹 생성 requests
+- Added layer-to-Transform tree guidance for raster mockups so visual layers are decomposed into cleaner Unity Transform/RectTransform hierarchy before object creation
+- Added item-level UI rect guidance for split runtime leaves, repeated cards, slots, rows, icons, and buttons, including source rect, normalized rect, Unity fit intent, and asset/crop plan
+- Added candidate item ledger guidance for semi-automated raster analysis, including confidence, evidence, review decision, and a human gate before object promotion
 - Added Stitch HTML/CSS to UGUI conversion guidance for treating exported front-end structure as a hierarchy source instead of a literal web-runtime copy
 - Added Figma node-tree to UGUI conversion guidance for mapping frames, groups, components, instances, and auto-layout into reusable Unity hierarchy
 - Added practical Stitch export and Figma export example prompts for structure-first UGUI conversion
+- Added focused keyword validation scripts for trigger wording, layer/tree decomposition, item rect contracts, and candidate ledger coverage
 
 ### Added / 추가
 
+- 첨부 UI 목업, 디자인 스크린샷, reference image, UI 시안, Unity UI prefab 또는 프리팹 생성 요청이 스킬 트리거로 잡히도록 문구 보강
+- raster mockup의 visual layer를 오브젝트 생성 전에 더 깨끗한 Unity Transform/RectTransform hierarchy로 분해하기 위한 layer-to-Transform tree 가이드 추가
+- 분리되는 runtime leaf, 반복 card, slot, row, icon, button을 위해 source rect, normalized rect, Unity fit intent, asset/crop plan을 포함한 item-level UI rect 가이드 추가
+- 반자동 raster 분석을 위해 confidence, evidence, review decision, human gate를 기록하는 candidate item ledger 가이드 추가
 - exported front-end 구조를 웹 런타임 복사본이 아니라 hierarchy source로 다루기 위한 Stitch HTML/CSS -> UGUI 변환 가이드 추가
 - frame, group, component, instance, auto-layout을 재사용 가능한 Unity 계층으로 옮기기 위한 Figma node-tree -> UGUI 변환 가이드 추가
 - structure-first UGUI 변환용 Stitch export 및 Figma export 실전 예시 프롬프트 추가
+- trigger wording, layer/tree decomposition, item rect contract, candidate ledger coverage를 확인하는 집중 keyword validation script 추가
 
 ### Changed
 
@@ -24,6 +38,8 @@ This project follows a lightweight documentation-focused release flow.
 - Clarified Figma export mapping so UGUI pivots are selected from UI role, constraints, growth, or motion intent rather than Figma's top-left coordinate origin
 - Strengthened Figma export guidance so auto-layout and regular repeated siblings default to UGUI layout components instead of per-child manual placement
 - Synchronized platform adapters with the new structured export hierarchy-source guidance
+- Refreshed the root README so the repository map, validation entry points, and current mockup-to-prefab workflow are easier to discover
+- Synchronized release and maintenance guidance with the trigger, layer-tree, item rect, and candidate ledger validation checks
 
 ### Changed / 변경
 
@@ -31,6 +47,8 @@ This project follows a lightweight documentation-focused release flow.
 - Figma export 변환 시 UGUI pivot을 Figma의 좌상단 좌표 원점이 아니라 UI 역할, constraints, growth, motion intent 기준으로 선택하도록 명확화
 - Figma export의 auto-layout 및 규칙적인 반복 sibling이 per-child 수동 배치 대신 UGUI layout component를 기본으로 쓰도록 가이드 강화
 - 새 structured export hierarchy-source 가이드와 맞도록 platform adapter 문서를 동기화
+- 저장소 구조, 검증 진입점, 현재 mockup-to-prefab workflow가 더 잘 보이도록 루트 README 갱신
+- trigger, layer-tree, item rect, candidate ledger validation check와 맞도록 release/maintenance 가이드 동기화
 
 ## v0.5.0 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Reusable Unity UI workflow rules for `unity-mcp`, packaged first as a Codex skil
 
 `unity-mcp`를 사용할 때 Unity UI를 더 안정적으로 만들기 위한 워크플로 규칙 모음입니다. 기본 형태는 Codex 스킬이며, 다른 LLM 플랫폼에서도 사용할 수 있도록 확장되어 있습니다.
 
-The repository is built around one core idea: when an LLM creates Unity UI from a mockup, screenshot, or target resolution, it should work from anchors, parent containers, scaling rules, and verification loops instead of raw pixel placement.
+The repository is built around one core idea: when an LLM creates Unity UI from a mockup, screenshot, structured export, or target resolution, it should work from anchors, parent containers, scaling rules, and verification loops instead of raw pixel placement.
 
-이 저장소의 핵심 아이디어는 하나입니다. LLM이 목업, 스크린샷, 목표 해상도를 바탕으로 Unity UI를 만들 때, 절대 픽셀값이 아니라 앵커, 부모 컨테이너, 스케일링 규칙, 검증 루프를 기준으로 작업해야 한다는 점입니다.
+이 저장소의 핵심 아이디어는 하나입니다. LLM이 목업, 스크린샷, structured export, 목표 해상도를 바탕으로 Unity UI를 만들 때, 절대 픽셀값이 아니라 앵커, 부모 컨테이너, 스케일링 규칙, 검증 루프를 기준으로 작업해야 한다는 점입니다.
 
 It also assumes three practical defaults: group the top-level composition by anchor-owned regions first, turn repeated structures into reusable prefabs or reusable layout blocks, and keep likely single-image resources intact unless runtime behavior requires them to be split.
 
@@ -102,6 +102,10 @@ Platform-specific adapters live in:
 
 - image-to-layout translation
 - attached UI mockup or design screenshot to Unity UI prefab creation
+- natural trigger coverage for uploaded mockups, reference images, UI 시안, and 프리팹 생성 requests
+- layer-to-Transform tree planning before Unity object creation
+- candidate item ledgers for semi-automated raster analysis before object promotion
+- item-level UI rect contracts for split runtime leaves, repeated rows, slots, cards, icons, and buttons
 - UGUI anchors and `CanvasScaler`
 - HUD, inventory, popup, and mobile safe-area layout rules
 - prefab promotion rules for repeated UI structures
@@ -185,13 +189,20 @@ Platform/
 
 examples/
   README.md
-  first-layout-pass-example.md
-  hud-example.md
-  inventory-example.md
-  popup-safe-area-example.md
+  *-example.md
 
+tests/
+  trigger_keywords.sh
+  layer_tree_keywords.sh
+  item_rect_keywords.sh
+  item_candidate_keywords.sh
+
+BACKLOG.md
 CONTRIBUTING.md
 CHANGELOG.md
+LICENSE
+MAINTENANCE.md
+RELEASE_CHECKLIST.md
 ```
 
 ## How The Pieces Fit / 구성 관계
@@ -205,12 +216,14 @@ Use this section as the repo map: start with the skill, choose an example, then 
 - `examples/` contains copyable task-shaped prompts that show how to apply the skill without rereading the whole reference set.
 - `Platform/` adapts the same core workflow to other LLM environments while keeping the Codex skill as the canonical source.
 - `unity-mcp-ui-layout/agents/` contains lightweight metadata used for agent discovery and default invocation text.
+- `tests/` contains keyword and metadata checks for trigger coverage, layer-tree guidance, item rect contracts, and candidate ledgers.
 
 - `unity-mcp-ui-layout/SKILL.md`는 빠른 의사결정 레이어입니다. UI 스택을 고르고, repair/build 모드를 정하고, vertical slice로 진행하고, 마무리 전 검증하는 흐름을 담습니다.
 - `unity-mcp-ui-layout/references/`는 실패 패턴, UI 유형, 자산 판단, fallback 규칙 같은 깊은 세부 지식을 담습니다.
 - `examples/`는 전체 레퍼런스를 다시 읽지 않아도 바로 적용할 수 있는 작업형 프롬프트 예시를 담습니다.
 - `Platform/`은 같은 코어 워크플로를 다른 LLM 환경에 맞게 옮긴 어댑터이며, 정본은 여전히 Codex 스킬입니다.
 - `unity-mcp-ui-layout/agents/`는 에이전트 검색과 기본 호출 문구에 쓰이는 가벼운 메타데이터를 담습니다.
+- `tests/`는 trigger coverage, layer-tree guidance, item rect contract, candidate ledger가 문서와 메타데이터에 남아 있는지 확인하는 keyword/metadata check를 담습니다.
 
 ## Release Notes / 릴리스 노트
 
@@ -221,6 +234,20 @@ Use this section as the repo map: start with the skill, choose an example, then 
 
 - [`RELEASE_CHECKLIST.md`](./RELEASE_CHECKLIST.md)
 - [`MAINTENANCE.md`](./MAINTENANCE.md)
+
+## Validation / 검증
+
+Run the focused checks when release prep or discoverability wording changes.
+
+릴리스 준비나 discoverability 문구를 바꾼 경우 아래 집중 검증을 실행합니다.
+
+```bash
+bash tests/trigger_keywords.sh
+bash tests/layer_tree_keywords.sh
+bash tests/item_rect_keywords.sh
+bash tests/item_candidate_keywords.sh
+python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py unity-mcp-ui-layout
+```
 
 ## Platform Notes / 플랫폼 설명
 


### PR DESCRIPTION
## Summary
- refresh the root README repository map, workflow discoverability, and validation entry points
- promote the accumulated post-v0.5.0 notes into CHANGELOG v0.6.0
- update BACKLOG to track post-v0.6.0 work

Closes #66.

## Validation
- bash -n tests/trigger_keywords.sh && bash tests/trigger_keywords.sh
- bash -n tests/layer_tree_keywords.sh && bash tests/layer_tree_keywords.sh
- bash -n tests/item_rect_keywords.sh && bash tests/item_rect_keywords.sh
- bash -n tests/item_candidate_keywords.sh && bash tests/item_candidate_keywords.sh
- python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py unity-mcp-ui-layout
- ruby -e 'require "yaml"; YAML.load_file("unity-mcp-ui-layout/agents/openai.yaml"); puts "ok"'\n- git diff --check\n\nNote: shellcheck is not installed in this environment.