### PR TITLE
[codex] Add mockup layout plan schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ This project follows a lightweight documentation-focused release flow.
 
 - Added a Unity UI layout snapshot contract for MCP intake before existing UI edits, including UGUI and UI Toolkit example payloads plus smaller-call fallback guidance
 - Added layout snapshot keyword validation for the snapshot contract, skill entry point, agent metadata, MCP recipes, review checks, and maintenance docs
+- Added a mockup layout plan template, filled prefab-from-mockup example, and schema validator for layer tree, candidate ledger, item rect, asset crop, and verification target planning
 
 ### Added / 추가
 
 - 기존 Unity UI 편집 전에 MCP intake로 사용할 Unity UI layout snapshot contract를 추가하고, UGUI/UI Toolkit 예시 payload와 smaller-call fallback 가이드를 포함
 - snapshot contract, skill entry point, agent metadata, MCP recipe, review check, maintenance docs를 확인하는 layout snapshot keyword validation 추가
+- layer tree, candidate ledger, item rect, asset crop, verification target planning을 위한 mockup layout plan template, prefab-from-mockup 예제, schema validator 추가
 
 ## v0.6.0 - 2026-06-26
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -24,6 +24,7 @@ Global Codex skill path:
 robocopy D:\UnityUICreater\unity-mcp-ui-layout C:\Users\user\.codex\skills\unity-mcp-ui-layout /MIR
 python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.py D:\UnityUICreater\unity-mcp-ui-layout
 bash D:/UnityUICreater/tests/layout_snapshot_keywords.sh
+bash D:/UnityUICreater/tests/mockup_layout_plan_schema.sh
 bash D:/UnityUICreater/tests/trigger_keywords.sh
 bash D:/UnityUICreater/tests/layer_tree_keywords.sh
 bash D:/UnityUICreater/tests/item_rect_keywords.sh
@@ -66,6 +67,7 @@ flowchart TD
 
 - frontmatter is still valid and readable
 - layout snapshot keyword checks still cover active root, UI stack, screenshot frame, fallback calls, and console state wording
+- mockup layout plan schema checks still cover required sections and accept/hold/reject promotion rules
 - trigger keyword checks still cover mockup/image-to-prefab request wording
 - layer/tree keyword checks still cover mockup-to-Transform hierarchy wording
 - item rect keyword checks still cover mockup item sizing and crop-plan wording
@@ -76,6 +78,7 @@ flowchart TD
 
 - frontmatter가 여전히 정상 파싱되는지 확인합니다.
 - layout snapshot keyword check가 active root, UI stack, screenshot frame, fallback call, console state 문구를 계속 커버하는지 확인합니다.
+- mockup layout plan schema check가 required section과 accept/hold/reject promotion rule을 계속 커버하는지 확인합니다.
 - mockup/image-to-prefab 요청 표현을 trigger keyword check가 계속 커버하는지 확인합니다.
 - mockup-to-Transform hierarchy 표현을 layer/tree keyword check가 계속 커버하는지 확인합니다.
 - mockup item sizing과 crop-plan 표현을 item rect keyword check가 계속 커버하는지 확인합니다.

--- a/README.md
+++ b/README.md
@@ -191,8 +191,12 @@ examples/
   README.md
   *-example.md
 
+templates/
+  mockup-layout-plan.yaml
+
 tests/
   layout_snapshot_keywords.sh
+  mockup_layout_plan_schema.sh
   trigger_keywords.sh
   layer_tree_keywords.sh
   item_rect_keywords.sh
@@ -244,6 +248,7 @@ Run the focused checks when release prep or discoverability wording changes.
 
 ```bash
 bash tests/layout_snapshot_keywords.sh
+bash tests/mockup_layout_plan_schema.sh
 bash tests/trigger_keywords.sh
 bash tests/layer_tree_keywords.sh
 bash tests/item_rect_keywords.sh

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -30,6 +30,7 @@ Use this checklist when preparing a tagged release for this repository.
 
 - validate the repo skill
 - run layout snapshot keyword checks when Unity UI intake, snapshot contracts, or smaller-call fallback wording changed
+- run mockup layout plan schema checks when the plan template, example, candidate promotion rules, or validator changed
 - run trigger keyword checks when discoverability or skill activation wording changed
 - run layer/tree keyword checks when mockup decomposition or hierarchy guidance changed
 - run item rect keyword checks when mockup item sizing, source rect, or crop-plan guidance changed
@@ -40,6 +41,7 @@ Use this checklist when preparing a tagged release for this repository.
 
 - 저장소 안의 정본 스킬을 검증합니다.
 - Unity UI intake, snapshot contract, smaller-call fallback 문구가 바뀌었다면 layout snapshot keyword check를 실행합니다.
+- plan template, example, candidate promotion rule, validator가 바뀌었다면 mockup layout plan schema check를 실행합니다.
 - discoverability나 스킬 작동 트리거 문구가 바뀌었다면 trigger keyword check를 실행합니다.
 - mockup decomposition이나 hierarchy 지침이 바뀌었다면 layer/tree keyword check를 실행합니다.
 - mockup item sizing, source rect, crop-plan 지침이 바뀌었다면 item rect keyword check를 실행합니다.
@@ -53,6 +55,7 @@ Use this checklist when preparing a tagged release for this repository.
 ```powershell
 python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.py D:\UnityUICreater\unity-mcp-ui-layout
 bash D:/UnityUICreater/tests/layout_snapshot_keywords.sh
+bash D:/UnityUICreater/tests/mockup_layout_plan_schema.sh
 bash D:/UnityUICreater/tests/trigger_keywords.sh
 bash D:/UnityUICreater/tests/layer_tree_keywords.sh
 bash D:/UnityUICreater/tests/item_rect_keywords.sh

--- a/examples/mockup-layout-plan-prefab-example.yaml
+++ b/examples/mockup-layout-plan-prefab-example.yaml
@@ -1,0 +1,144 @@
+schema_version: "mockup-layout-plan/v1"
+plan_id: "mockup-layout-plan/reward-card-prefab"
+layout_contract:
+  ui_stack: "UGUI"
+  mode: "build"
+  mockup_source: "attached reward-card mockup"
+  reference_resolution: "1920x1080"
+  target_resolution: "1920x1080"
+  root_owner: "Canvas/SafeAreaRoot/RewardPopupRoot"
+  structure_rule: "parent ownership before leaf sizing"
+  candidate_policy:
+    accepted: "may become item rect entries after parent ownership and split reason are reviewed"
+    held: "remain review notes and must not create Unity objects, prefab children, or crops"
+    rejected: "must not create Unity objects, prefab children, or crops"
+layer_tree:
+  - node_path: "Canvas/SafeAreaRoot/RewardPopupRoot"
+    role: "region"
+    parent_owner: "Canvas/SafeAreaRoot"
+    unity_type: "RectTransform"
+    anchor_pivot_intent: "centered"
+    layout_owner: "manual modal bounds"
+    geometry_ratios:
+      x: 0.275
+      y: 0.16
+      width: 0.45
+      height: 0.68
+    split_keep_reason: "modal owns reward composition"
+  - node_path: "Canvas/SafeAreaRoot/RewardPopupRoot/RewardCard"
+    role: "reusable group"
+    parent_owner: "Canvas/SafeAreaRoot/RewardPopupRoot"
+    unity_type: "prefab root"
+    anchor_pivot_intent: "centered"
+    layout_owner: "VerticalLayoutGroup"
+    geometry_ratios:
+      x: 0.335
+      y: 0.25
+      width: 0.33
+      height: 0.44
+    split_keep_reason: "reward card repeats across reward screens"
+  - node_path: "Canvas/SafeAreaRoot/RewardPopupRoot/RewardCard/Icon"
+    role: "runtime leaf"
+    parent_owner: "Canvas/SafeAreaRoot/RewardPopupRoot/RewardCard"
+    unity_type: "RectTransform"
+    anchor_pivot_intent: "centered"
+    layout_owner: "LayoutElement"
+    geometry_ratios:
+      x: 0.455
+      y: 0.34
+      width: 0.09
+      height: 0.16
+    split_keep_reason: "dynamic reward icon"
+candidate_item_ledger:
+  - candidate_id: "candidate/RewardCard/Icon"
+    source_bounds:
+      x: 874
+      y: 367
+      width: 172
+      height: 172
+    confidence_band: "high"
+    evidence:
+      - "centered icon cluster"
+      - "strong contrast boundary"
+      - "dynamic reward content"
+    suggested_role: "icon"
+    parent_hint: "Canvas/SafeAreaRoot/RewardPopupRoot/RewardCard"
+    crop_padding: "12px glow should stay outside icon sprite"
+    nine_slice_candidate: false
+    review_decision: "accept"
+    decision_note: "dynamic reward icon needs runtime sprite swap"
+  - candidate_id: "candidate/RewardCard/OuterGlow"
+    source_bounds:
+      x: 620
+      y: 245
+      width: 680
+      height: 560
+    confidence_band: "medium"
+    evidence:
+      - "soft panel shadow"
+      - "decorative frame"
+    suggested_role: "hold-for-review"
+    parent_hint: "Canvas/SafeAreaRoot/RewardPopupRoot/RewardCard"
+    crop_padding: "unknown"
+    nine_slice_candidate: false
+    review_decision: "hold"
+    decision_note: "may be baked into card background; do not promote without art review"
+  - candidate_id: "candidate/RewardCard/InnerHighlightLine"
+    source_bounds:
+      x: 674
+      y: 308
+      width: 572
+      height: 3
+    confidence_band: "medium"
+    evidence:
+      - "decorative separator"
+    suggested_role: "decorative image"
+    parent_hint: "Canvas/SafeAreaRoot/RewardPopupRoot/RewardCard"
+    crop_padding: "none"
+    nine_slice_candidate: false
+    review_decision: "reject"
+    decision_note: "decorative sub-part stays inside card background art"
+item_rect_plan:
+  - item_id: "RewardCard/Icon"
+    candidate_id: "candidate/RewardCard/Icon"
+    node_path: "Canvas/SafeAreaRoot/RewardPopupRoot/RewardCard/Icon"
+    source_rect:
+      x: 874
+      y: 367
+      width: 172
+      height: 172
+    normalized_rect:
+      x: 0.4552
+      y: 0.3398
+      width: 0.0896
+      height: 0.1593
+    parent_local_rect:
+      x: 0
+      y: -24
+      width: 172
+      height: 172
+    fit_mode: "preserve-aspect"
+    anchor_pivot_intent: "centered"
+    split_keep_reason: "dynamic reward icon"
+    asset_crop_plan_id: "crop/RewardCard/Icon"
+asset_crop_plan:
+  - asset_crop_plan_id: "crop/RewardCard/Icon"
+    item_id: "RewardCard/Icon"
+    candidate_id: "candidate/RewardCard/Icon"
+    plan: "reuse reward icon sprite if found; otherwise import mockup-derived icon crop as provisional"
+    source: "existing sprite preferred"
+    nine_slice: false
+    creates_unity_object: true
+verification_targets:
+  - target: "prefab instance screenshot"
+    resolution: "1920x1080"
+    checks:
+      - "RewardCard prefab root owns icon placement"
+      - "RewardCard/Icon uses preserve-aspect fit"
+      - "held glow did not create a prefab child"
+      - "rejected highlight line did not create a crop"
+  - target: "alternate aspect screenshot"
+    resolution: "1600x900"
+    checks:
+      - "RewardPopupRoot remains centered"
+      - "RewardCard spacing is owned by VerticalLayoutGroup"

--- a/examples/prefab-from-mockup-example.md
+++ b/examples/prefab-from-mockup-example.md
@@ -19,6 +19,7 @@ Inspect whether the project uses UGUI or UI Toolkit before creating objects.
 Run a layer-to-tree pass so the visual layers become a clean Transform/RectTransform hierarchy before prefab creation.
 If semi-automated item detection is helpful, create a candidate item ledger with confidence band, evidence, crop padding, and review decision before item rect planning.
 For split runtime leaves and repeated prefab units, create an item rect plan with source rect, normalized rect, parent-local rect or fit mode, and asset/crop plan.
+Use the mockup layout plan template if you need a fixed artifact: templates/mockup-layout-plan.yaml.
 Group the top-level screen into anchor-owned parent regions first.
 Turn repeated cards, slots, buttons, or rows into reusable prefabs or reusable layout blocks.
 Keep decorative baked regions as single image assets unless runtime behavior requires splitting.
@@ -32,6 +33,7 @@ Verify the created prefab instance with a screenshot.
 프리팹을 만들기 전에 layer-to-tree pass를 실행해서 시각 레이어가 깔끔한 Transform/RectTransform hierarchy가 되게 해줘.
 반자동 item detection을 쓴다면 confidence band, evidence, crop padding, review decision이 포함된 candidate item ledger를 먼저 만들고 검토해줘.
 분리되는 runtime leaf와 반복 프리팹 단위는 source rect, normalized rect, parent-local rect 또는 fit mode, asset/crop plan이 포함된 item rect plan을 먼저 만들어줘.
+고정된 산출물이 필요하면 templates/mockup-layout-plan.yaml 형식으로 정리해줘.
 화면을 anchor 기준 부모 영역으로 나눈 다음, 반복되는 카드/슬롯/버튼/행은 재사용 가능한 프리팹이나 레이아웃 블록으로 만들어줘.
 장식용으로 구워진 영역은 런타임 동작상 분리가 필요할 때만 나눠줘.
 생성한 프리팹 인스턴스를 스크린샷으로 검증해줘.
@@ -49,9 +51,12 @@ Verify the created prefab instance with a screenshot.
 - It routes prefab creation through the same structure-first layout rules as screen creation.
 - It prevents over-decomposition by checking runtime responsibility before splitting assets.
 - It makes reusable prefab extraction explicit when the design repeats.
+- It can produce a fixed mockup layout plan artifact so candidate review decisions stay separate from item rects and crop plans.
 
 ## Suggested References
 
+- [mockup-layout-plan.yaml](../templates/mockup-layout-plan.yaml)
+- [mockup-layout-plan-prefab-example.yaml](./mockup-layout-plan-prefab-example.yaml)
 - [image-to-layout.md](../unity-mcp-ui-layout/references/image-to-layout.md)
 - [mockup-decomposition.md](../unity-mcp-ui-layout/references/mockup-decomposition.md)
 - [prefab-reuse.md](../unity-mcp-ui-layout/references/prefab-reuse.md)

--- a/templates/mockup-layout-plan.yaml
+++ b/templates/mockup-layout-plan.yaml
@@ -1,0 +1,141 @@
+schema_version: "mockup-layout-plan/v1"
+plan_id: "mockup-layout-plan/<screen-or-prefab>"
+layout_contract:
+  ui_stack: "UGUI"
+  mode: "build"
+  mockup_source: "attached mockup image"
+  reference_resolution: "1920x1080"
+  target_resolution: "1920x1080"
+  root_owner: "Canvas/SafeAreaRoot/ScreenRoot"
+  structure_rule: "parent ownership before leaf sizing"
+  candidate_policy:
+    accepted: "may become item rect entries after parent ownership and split reason are reviewed"
+    held: "remain review notes and must not create Unity objects, prefab children, or crops"
+    rejected: "must not create Unity objects, prefab children, or crops"
+layer_tree:
+  - node_path: "Canvas/SafeAreaRoot/ScreenRoot"
+    role: "shell"
+    parent_owner: "Canvas/SafeAreaRoot"
+    unity_type: "RectTransform"
+    anchor_pivot_intent: "stretch"
+    layout_owner: "manual shell bounds"
+    geometry_ratios:
+      x: 0.0
+      y: 0.0
+      width: 1.0
+      height: 1.0
+    split_keep_reason: "root layout container"
+  - node_path: "Canvas/SafeAreaRoot/ScreenRoot/RepeatedGroup"
+    role: "reusable group"
+    parent_owner: "Canvas/SafeAreaRoot/ScreenRoot"
+    unity_type: "prefab root"
+    anchor_pivot_intent: "parent-flow child"
+    layout_owner: "layout group"
+    geometry_ratios:
+      x: 0.1
+      y: 0.2
+      width: 0.8
+      height: 0.3
+    split_keep_reason: "repeated runtime item"
+  - node_path: "Canvas/SafeAreaRoot/ScreenRoot/RepeatedGroup/Item"
+    role: "runtime leaf"
+    parent_owner: "Canvas/SafeAreaRoot/ScreenRoot/RepeatedGroup"
+    unity_type: "RectTransform"
+    anchor_pivot_intent: "parent-flow child"
+    layout_owner: "LayoutElement"
+    geometry_ratios:
+      x: 0.1
+      y: 0.2
+      width: 0.1667
+      height: 0.1667
+    split_keep_reason: "repeated runtime data"
+candidate_item_ledger:
+  - candidate_id: "candidate/RepeatedGroup/Item01"
+    source_bounds:
+      x: 192
+      y: 216
+      width: 320
+      height: 180
+    confidence_band: "high"
+    evidence:
+      - "repeated shape"
+      - "shared baseline"
+    suggested_role: "repeated item unit"
+    parent_hint: "Canvas/SafeAreaRoot/ScreenRoot/RepeatedGroup"
+    crop_padding: "8px visual shadow"
+    nine_slice_candidate: false
+    review_decision: "accept"
+    decision_note: "same structure repeats and needs runtime data binding"
+  - candidate_id: "candidate/Decorative/Glow"
+    source_bounds:
+      x: 80
+      y: 80
+      width: 260
+      height: 120
+    confidence_band: "low"
+    evidence:
+      - "soft contrast boundary"
+    suggested_role: "hold-for-review"
+    parent_hint: "Canvas/SafeAreaRoot/ScreenRoot"
+    crop_padding: "unknown"
+    nine_slice_candidate: false
+    review_decision: "hold"
+    decision_note: "visual boundary is uncertain; keep as review note"
+  - candidate_id: "candidate/Frame/InnerLine"
+    source_bounds:
+      x: 100
+      y: 100
+      width: 400
+      height: 2
+    confidence_band: "medium"
+    evidence:
+      - "decorative line"
+    suggested_role: "decorative image"
+    parent_hint: "Canvas/SafeAreaRoot/ScreenRoot"
+    crop_padding: "none"
+    nine_slice_candidate: false
+    review_decision: "reject"
+    decision_note: "decorative sub-part stays inside baked art"
+item_rect_plan:
+  - item_id: "RepeatedGroup/Item01"
+    candidate_id: "candidate/RepeatedGroup/Item01"
+    node_path: "Canvas/SafeAreaRoot/ScreenRoot/RepeatedGroup/Item"
+    source_rect:
+      x: 192
+      y: 216
+      width: 320
+      height: 180
+    normalized_rect:
+      x: 0.1
+      y: 0.2
+      width: 0.1667
+      height: 0.1667
+    parent_local_rect:
+      x: 0
+      y: 0
+      width: 320
+      height: 180
+    fit_mode: "layout-group child"
+    anchor_pivot_intent: "parent-flow child"
+    split_keep_reason: "repeated runtime data"
+    asset_crop_plan_id: "crop/RepeatedGroup/ItemFrame"
+asset_crop_plan:
+  - asset_crop_plan_id: "crop/RepeatedGroup/ItemFrame"
+    item_id: "RepeatedGroup/Item01"
+    candidate_id: "candidate/RepeatedGroup/Item01"
+    plan: "reuse existing prefab frame if available; otherwise placeholder until art import"
+    source: "existing prefab preferred"
+    nine_slice: false
+    creates_unity_object: true
+verification_targets:
+  - target: "main screenshot"
+    resolution: "1920x1080"
+    checks:
+      - "parent-owned hierarchy matches layer_tree"
+      - "accepted candidates mapped to item_rect_plan only after review"
+      - "held and rejected candidates did not create objects or crops"
+  - target: "alternate aspect screenshot"
+    resolution: "1600x900"
+    checks:
+      - "repeated group remains parent-owned"
+      - "item size uses fit_mode instead of full-screen offsets"

--- a/tests/mockup_layout_plan_schema.sh
+++ b/tests/mockup_layout_plan_schema.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+assert_contains() {
+  local file_path="$1"
+  local needle="$2"
+
+  if ! grep -Fqi "$needle" "$file_path"; then
+    printf 'Missing mockup layout plan phrase in %s: %s\n' "$file_path" "$needle" >&2
+    return 1
+  fi
+}
+
+assert_contains "$ROOT_DIR/unity-mcp-ui-layout/references/image-to-layout.md" "../../templates/mockup-layout-plan.yaml"
+assert_contains "$ROOT_DIR/unity-mcp-ui-layout/references/mockup-decomposition.md" "../../templates/mockup-layout-plan.yaml"
+assert_contains "$ROOT_DIR/unity-mcp-ui-layout/references/prompt-patterns.md" "../../templates/mockup-layout-plan.yaml"
+assert_contains "$ROOT_DIR/examples/prefab-from-mockup-example.md" "../templates/mockup-layout-plan.yaml"
+assert_contains "$ROOT_DIR/examples/prefab-from-mockup-example.md" "mockup-layout-plan-prefab-example.yaml"
+
+ruby - "$ROOT_DIR/templates/mockup-layout-plan.yaml" "$ROOT_DIR/examples/mockup-layout-plan-prefab-example.yaml" <<'RUBY'
+require "yaml"
+
+paths = ARGV
+
+REQUIRED_ROOT_KEYS = %w[
+  schema_version
+  plan_id
+  layout_contract
+  layer_tree
+  candidate_item_ledger
+  item_rect_plan
+  asset_crop_plan
+  verification_targets
+].freeze
+
+REQUIRED_CONTRACT_KEYS = %w[
+  ui_stack
+  mode
+  mockup_source
+  reference_resolution
+  target_resolution
+  root_owner
+  structure_rule
+  candidate_policy
+].freeze
+
+REQUIRED_POLICY_KEYS = %w[
+  accepted
+  held
+  rejected
+].freeze
+
+REQUIRED_LAYER_KEYS = %w[
+  node_path
+  role
+  parent_owner
+  unity_type
+  anchor_pivot_intent
+  layout_owner
+  geometry_ratios
+  split_keep_reason
+].freeze
+
+REQUIRED_CANDIDATE_KEYS = %w[
+  candidate_id
+  source_bounds
+  confidence_band
+  evidence
+  suggested_role
+  parent_hint
+  crop_padding
+  nine_slice_candidate
+  review_decision
+  decision_note
+].freeze
+
+REQUIRED_ITEM_RECT_KEYS = %w[
+  item_id
+  candidate_id
+  node_path
+  source_rect
+  normalized_rect
+  parent_local_rect
+  fit_mode
+  anchor_pivot_intent
+  split_keep_reason
+  asset_crop_plan_id
+].freeze
+
+REQUIRED_CROP_KEYS = %w[
+  asset_crop_plan_id
+  item_id
+  candidate_id
+  plan
+  source
+  nine_slice
+  creates_unity_object
+].freeze
+
+REQUIRED_RECT_KEYS = %w[x y width height].freeze
+
+def fail_with(path, message)
+  warn "#{path}: #{message}"
+  exit 1
+end
+
+def require_hash(path, value, label)
+  fail_with(path, "#{label} must be a map") unless value.is_a?(Hash)
+end
+
+def require_array(path, value, label)
+  fail_with(path, "#{label} must be a non-empty list") unless value.is_a?(Array) && !value.empty?
+end
+
+def require_keys(path, hash, keys, label)
+  missing = keys.reject { |key| hash.key?(key) }
+  fail_with(path, "#{label} missing keys: #{missing.join(', ')}") unless missing.empty?
+end
+
+def require_rect(path, rect, label)
+  require_hash(path, rect, label)
+  require_keys(path, rect, REQUIRED_RECT_KEYS, label)
+end
+
+paths.each do |path|
+  data = YAML.load_file(path)
+  require_hash(path, data, "document")
+  require_keys(path, data, REQUIRED_ROOT_KEYS, "root")
+
+  contract = data.fetch("layout_contract")
+  require_hash(path, contract, "layout_contract")
+  require_keys(path, contract, REQUIRED_CONTRACT_KEYS, "layout_contract")
+  policy = contract.fetch("candidate_policy")
+  require_hash(path, policy, "candidate_policy")
+  require_keys(path, policy, REQUIRED_POLICY_KEYS, "candidate_policy")
+
+  layer_tree = data.fetch("layer_tree")
+  candidates = data.fetch("candidate_item_ledger")
+  item_rects = data.fetch("item_rect_plan")
+  crop_plans = data.fetch("asset_crop_plan")
+  verification_targets = data.fetch("verification_targets")
+
+  require_array(path, layer_tree, "layer_tree")
+  require_array(path, candidates, "candidate_item_ledger")
+  require_array(path, item_rects, "item_rect_plan")
+  require_array(path, crop_plans, "asset_crop_plan")
+  require_array(path, verification_targets, "verification_targets")
+
+  layer_paths = layer_tree.map do |layer|
+    require_hash(path, layer, "layer_tree entry")
+    require_keys(path, layer, REQUIRED_LAYER_KEYS, "layer_tree entry")
+    require_rect(path, layer.fetch("geometry_ratios"), "geometry_ratios")
+    layer.fetch("node_path")
+  end
+
+  decisions = {}
+  candidates.each do |candidate|
+    require_hash(path, candidate, "candidate entry")
+    require_keys(path, candidate, REQUIRED_CANDIDATE_KEYS, "candidate entry")
+    require_rect(path, candidate.fetch("source_bounds"), "source_bounds")
+    decision = candidate.fetch("review_decision")
+    unless %w[accept hold reject].include?(decision)
+      fail_with(path, "candidate #{candidate.fetch('candidate_id')} has invalid review_decision: #{decision}")
+    end
+    evidence = candidate.fetch("evidence")
+    require_array(path, evidence, "candidate evidence")
+    decisions[candidate.fetch("candidate_id")] = decision
+  end
+
+  item_rect_candidate_ids = item_rects.map do |item|
+    require_hash(path, item, "item_rect_plan entry")
+    require_keys(path, item, REQUIRED_ITEM_RECT_KEYS, "item_rect_plan entry")
+    require_rect(path, item.fetch("source_rect"), "source_rect")
+    require_rect(path, item.fetch("normalized_rect"), "normalized_rect")
+    require_rect(path, item.fetch("parent_local_rect"), "parent_local_rect")
+    unless layer_paths.include?(item.fetch("node_path"))
+      fail_with(path, "item #{item.fetch('item_id')} node_path is not present in layer_tree")
+    end
+    item.fetch("candidate_id")
+  end
+
+  crop_candidate_ids = crop_plans.map do |crop|
+    require_hash(path, crop, "asset_crop_plan entry")
+    require_keys(path, crop, REQUIRED_CROP_KEYS, "asset_crop_plan entry")
+    crop.fetch("candidate_id")
+  end
+
+  accepted = decisions.select { |_id, decision| decision == "accept" }.keys
+  held = decisions.select { |_id, decision| decision == "hold" }.keys
+  rejected = decisions.select { |_id, decision| decision == "reject" }.keys
+
+  missing_item_rect = accepted - item_rect_candidate_ids
+  fail_with(path, "accepted candidates missing item_rect_plan entries: #{missing_item_rect.join(', ')}") unless missing_item_rect.empty?
+
+  disallowed_item_rect = (held + rejected) & item_rect_candidate_ids
+  fail_with(path, "held/rejected candidates must not appear in item_rect_plan: #{disallowed_item_rect.join(', ')}") unless disallowed_item_rect.empty?
+
+  disallowed_crop = (held + rejected) & crop_candidate_ids
+  fail_with(path, "held/rejected candidates must not appear in asset_crop_plan: #{disallowed_crop.join(', ')}") unless disallowed_crop.empty?
+
+  item_rects.each do |item|
+    crop_id = item.fetch("asset_crop_plan_id")
+    unless crop_plans.any? { |crop| crop.fetch("asset_crop_plan_id") == crop_id }
+      fail_with(path, "item #{item.fetch('item_id')} references missing asset_crop_plan_id: #{crop_id}")
+    end
+  end
+
+  verification_targets.each do |target|
+    require_hash(path, target, "verification target")
+    require_keys(path, target, %w[target resolution checks], "verification target")
+    require_array(path, target.fetch("checks"), "verification target checks")
+  end
+end
+RUBY

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -9,6 +9,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `layout-checklist.md`
 - `layout-snapshot-contract.md` - defines the ideal Unity UI layout snapshot MCP contract and smaller-call fallback before existing UI edits.
 - `image-to-layout.md` - includes mockup-to-layer-to-tree workflow, candidate item ledger guidance, item rect mapping, and the asset-RAG fallback contract for when `unity-resource-rag` is unavailable or low-confidence.
+- `../../templates/mockup-layout-plan.yaml` - provides a concise machine-readable artifact shape for layer tree, candidate ledger, item rect, asset crop, and verification target planning.
 - `mcp-call-recipes.md`
 - `mockup-decomposition.md` - owns layer-to-tree decomposition, parent ownership, split/keep decisions, and item rect contract for raster mockups.
 - `mockup-resolution.md`

--- a/unity-mcp-ui-layout/references/image-to-layout.md
+++ b/unity-mcp-ui-layout/references/image-to-layout.md
@@ -4,6 +4,7 @@ Use this guide when the user provides, uploads, attaches, or drops a layout imag
 
 Pair it with `mockup-resolution.md` when the mockup's own native pixel size should become the planning reference frame.
 Pair it with `mockup-decomposition.md` when you need a stricter rule for deciding what should stay as one asset versus what should become runtime-owned UI.
+Use `../../templates/mockup-layout-plan.yaml` when the agent needs a concise machine-readable plan for the layer tree, candidate item ledger, item rect plan, asset crop plan, and verification targets.
 
 ## Goal
 
@@ -94,6 +95,8 @@ Candidate ledger schema:
 Only accepted candidates can become item-level UI rect entries. Held candidates remain notes for manual review, and rejected candidates must not create Unity objects, crops, or prefab children.
 
 Do not use low-confidence candidates to force a split. If the candidate cannot name a parent hint, split/keep reason, and evidence, keep it in the nearest existing visual layer.
+
+For fixed-column planning output, copy `../../templates/mockup-layout-plan.yaml` and validate it with `../../tests/mockup_layout_plan_schema.sh`.
 
 ### 3. Run an item rect mapping pass
 

--- a/unity-mcp-ui-layout/references/mockup-decomposition.md
+++ b/unity-mcp-ui-layout/references/mockup-decomposition.md
@@ -2,6 +2,8 @@
 
 Use this guide when a mockup, screenshot, design image, or UI 시안 exists and you need to decide which regions should stay as one asset, which should become reusable layout blocks or Unity UI prefabs, and which should be separated into interactive UI elements.
 
+Use `../../templates/mockup-layout-plan.yaml` when the decomposition needs a concise machine-readable artifact for layer tree, candidate review, item rect, asset crop, and verification target decisions.
+
 ## Goal
 
 Decompose the mockup only as far as runtime behavior needs. Keep the hierarchy honest, avoid fake widget explosion, and preserve reusable structure where the design clearly repeats.
@@ -49,6 +51,8 @@ For each candidate, record:
 - decision note: why the candidate should become an item rect, stay inside a larger image, or wait for manual review
 
 Use accept/hold/reject instead of silently deleting uncertain candidates. Accepted candidates may become item-level UI rect entries. Held candidates remain review notes. Rejected candidates should not create Unity objects or mockup-derived crops.
+
+The template policy is strict: accepted candidates may become item rect entries after parent ownership and split reason are reviewed, held candidates remain notes, and rejected candidates must not create Unity objects, prefab children, or crops.
 
 For each runtime or repeated item, record:
 

--- a/unity-mcp-ui-layout/references/prompt-patterns.md
+++ b/unity-mcp-ui-layout/references/prompt-patterns.md
@@ -83,6 +83,8 @@ Use `manage_camera` for the screenshot capture.
 
 If no explicit target resolution is provided, use the mockup image's native resolution as the reference resolution instead of falling back immediately to `1920x1080`.
 
+When the plan needs fixed sections or will be reused across agents, use `../../templates/mockup-layout-plan.yaml` for the layer tree, candidate item ledger, item rect plan, asset crop plan, and verification targets.
+
 ## Pattern 6A: Mockup Screenshot To Prefab
 
 Use when the user uploads or drops a mockup screenshot, design image, reference image, or UI 시안 and asks to turn, convert, make, generate, or create a Unity UI prefab.
@@ -94,6 +96,8 @@ If using semi-automated item detection, produce a candidate item ledger first an
 For split runtime leaves and repeated prefab units, produce an item-level UI rect plan with source rect, normalized rect, parent-local rect or fit mode, and asset/crop plan.
 Create parent containers before leaf widgets, keep decorative baked regions whole unless runtime behavior requires splitting, and verify the prefab instance with a screenshot.
 ```
+
+For a structured planning artifact, copy `../../templates/mockup-layout-plan.yaml` and keep accepted, held, and rejected candidates separated before object creation.
 
 ## Pattern 7: Image-Based Layout Repair
 


### PR DESCRIPTION
## Summary
- add `templates/mockup-layout-plan.yaml` as a concise planning artifact for layer tree, candidate ledger, item rect, asset crop, and verification targets
- add `examples/mockup-layout-plan-prefab-example.yaml` as a filled prefab-from-mockup example
- add `tests/mockup_layout_plan_schema.sh` to validate required sections, required fields, accepted/held/rejected promotion rules, node path consistency, and crop plan references
- link the template from image-to-layout, mockup decomposition, prompt patterns, and the prefab-from-mockup example

Closes #69.

## Validation
- bash -n tests/mockup_layout_plan_schema.sh && bash tests/mockup_layout_plan_schema.sh
- bash -n tests/layout_snapshot_keywords.sh && bash tests/layout_snapshot_keywords.sh
- bash -n tests/trigger_keywords.sh && bash tests/trigger_keywords.sh
- bash -n tests/layer_tree_keywords.sh && bash tests/layer_tree_keywords.sh
- bash -n tests/item_rect_keywords.sh && bash tests/item_rect_keywords.sh
- bash -n tests/item_candidate_keywords.sh && bash tests/item_candidate_keywords.sh
- python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py unity-mcp-ui-layout
- ruby -e 'require "yaml"; YAML.load_file("unity-mcp-ui-layout/agents/openai.yaml"); YAML.load_file("templates/mockup-layout-plan.yaml"); YAML.load_file("examples/mockup-layout-plan-prefab-example.yaml"); puts "ok"'\n- git diff --check\n\nNote: shellcheck is not installed in this environment.