### PR TITLE
[codex] Add agent execution runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ This project follows a lightweight documentation-focused release flow.
 - Added a Unity UI layout snapshot contract for MCP intake before existing UI edits, including UGUI and UI Toolkit example payloads plus smaller-call fallback guidance
 - Added layout snapshot keyword validation for the snapshot contract, skill entry point, agent metadata, MCP recipes, review checks, and maintenance docs
 - Added a mockup layout plan template, filled prefab-from-mockup example, and schema validator for layer tree, candidate ledger, item rect, asset crop, and verification target planning
+- Added an agent execution runbook with trigger naming, task classification, build/repair/input-mode notes, and final response checklist
 
 ### Added / 추가
 
 - 기존 Unity UI 편집 전에 MCP intake로 사용할 Unity UI layout snapshot contract를 추가하고, UGUI/UI Toolkit 예시 payload와 smaller-call fallback 가이드를 포함
 - snapshot contract, skill entry point, agent metadata, MCP recipe, review check, maintenance docs를 확인하는 layout snapshot keyword validation 추가
 - layer tree, candidate ledger, item rect, asset crop, verification target planning을 위한 mockup layout plan template, prefab-from-mockup 예제, schema validator 추가
+- trigger naming, task classification, build/repair/input-mode note, final response checklist를 포함한 agent execution runbook 추가
 
 ## v0.6.0 - 2026-06-26
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -23,6 +23,7 @@ Global Codex skill path:
 ```powershell
 robocopy D:\UnityUICreater\unity-mcp-ui-layout C:\Users\user\.codex\skills\unity-mcp-ui-layout /MIR
 python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.py D:\UnityUICreater\unity-mcp-ui-layout
+bash D:/UnityUICreater/tests/agent_runbook_keywords.sh
 bash D:/UnityUICreater/tests/layout_snapshot_keywords.sh
 bash D:/UnityUICreater/tests/mockup_layout_plan_schema.sh
 bash D:/UnityUICreater/tests/trigger_keywords.sh
@@ -66,6 +67,7 @@ flowchart TD
 ## Lightweight Validation Checklist / 가벼운 검증 체크
 
 - frontmatter is still valid and readable
+- agent runbook keyword checks still cover trigger naming, task classification, Unity-state intake, input-mode notes, and final response checklist
 - layout snapshot keyword checks still cover active root, UI stack, screenshot frame, fallback calls, and console state wording
 - mockup layout plan schema checks still cover required sections and accept/hold/reject promotion rules
 - trigger keyword checks still cover mockup/image-to-prefab request wording
@@ -77,6 +79,7 @@ flowchart TD
 - no new file silently became the only source of important guidance
 
 - frontmatter가 여전히 정상 파싱되는지 확인합니다.
+- agent runbook keyword check가 trigger naming, task classification, Unity-state intake, input-mode note, final response checklist를 계속 커버하는지 확인합니다.
 - layout snapshot keyword check가 active root, UI stack, screenshot frame, fallback call, console state 문구를 계속 커버하는지 확인합니다.
 - mockup layout plan schema check가 required section과 accept/hold/reject promotion rule을 계속 커버하는지 확인합니다.
 - mockup/image-to-prefab 요청 표현을 trigger keyword check가 계속 커버하는지 확인합니다.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you are using this repository for the first time, do not start by reading eve
 3. Choose the change mode next: repair an existing screen or build a new one.
 4. Decide whether this is layout-only work or asset-aware reuse work.
 5. If the task includes Stitch HTML/CSS, Figma node-tree exports, `DESIGN.md`, design tokens, or another design source, identify whether it is a hierarchy source, a style source, or both before editing.
-6. Then open [`examples/README.md`](./examples/README.md) for a task-shaped entry point, or jump into [`unity-mcp-ui-layout/references/README.md`](./unity-mcp-ui-layout/references/README.md) if you already know the failure mode.
+6. Then open [`examples/README.md`](./examples/README.md) for a task-shaped entry point, [`unity-mcp-ui-layout/references/agent-runbook.md`](./unity-mcp-ui-layout/references/agent-runbook.md) for agent execution order, or jump into [`unity-mcp-ui-layout/references/README.md`](./unity-mcp-ui-layout/references/README.md) if you already know the failure mode.
 
 For a first small exercise, start with [`examples/first-layout-pass-example.md`](./examples/first-layout-pass-example.md) before choosing a more domain-specific example.
 
@@ -44,7 +44,7 @@ Codex should also treat natural requests such as "build this Unity UI from the a
 3. 그다음 기존 화면 수정인지, 신규 화면 생성인지 작업 모드를 고릅니다.
 4. 이 작업이 layout-only인지, asset-aware reuse까지 필요한지 결정합니다.
 5. 작업에 Stitch HTML/CSS, Figma node-tree export, `DESIGN.md`, design token, 또는 다른 design source가 포함되어 있다면 수정 전에 그것이 구조 소스인지, 스타일 소스인지, 둘 다인지 먼저 구분합니다.
-6. 그 후 작업형 진입점이 필요하면 [`examples/README.md`](./examples/README.md)를, 실패 유형을 이미 알고 있다면 [`unity-mcp-ui-layout/references/README.md`](./unity-mcp-ui-layout/references/README.md)를 엽니다.
+6. 그 후 작업형 진입점이 필요하면 [`examples/README.md`](./examples/README.md)를, 에이전트 실행 순서가 필요하면 [`unity-mcp-ui-layout/references/agent-runbook.md`](./unity-mcp-ui-layout/references/agent-runbook.md)를, 실패 유형을 이미 알고 있다면 [`unity-mcp-ui-layout/references/README.md`](./unity-mcp-ui-layout/references/README.md)를 엽니다.
 
 처음 해볼 작은 연습 과제가 필요하다면 더 구체적인 예시를 고르기 전에 [`examples/first-layout-pass-example.md`](./examples/first-layout-pass-example.md)부터 시작합니다.
 
@@ -195,6 +195,7 @@ templates/
   mockup-layout-plan.yaml
 
 tests/
+  agent_runbook_keywords.sh
   layout_snapshot_keywords.sh
   mockup_layout_plan_schema.sh
   trigger_keywords.sh
@@ -247,6 +248,7 @@ Run the focused checks when release prep or discoverability wording changes.
 릴리스 준비나 discoverability 문구를 바꾼 경우 아래 집중 검증을 실행합니다.
 
 ```bash
+bash tests/agent_runbook_keywords.sh
 bash tests/layout_snapshot_keywords.sh
 bash tests/mockup_layout_plan_schema.sh
 bash tests/trigger_keywords.sh

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -29,6 +29,7 @@ Use this checklist when preparing a tagged release for this repository.
 ## Validation / 검증
 
 - validate the repo skill
+- run agent runbook keyword checks when the agent operating sequence, mode notes, or final response checklist changed
 - run layout snapshot keyword checks when Unity UI intake, snapshot contracts, or smaller-call fallback wording changed
 - run mockup layout plan schema checks when the plan template, example, candidate promotion rules, or validator changed
 - run trigger keyword checks when discoverability or skill activation wording changed
@@ -40,6 +41,7 @@ Use this checklist when preparing a tagged release for this repository.
 - make sure new examples still match the actual rules
 
 - 저장소 안의 정본 스킬을 검증합니다.
+- agent operating sequence, mode note, final response checklist가 바뀌었다면 agent runbook keyword check를 실행합니다.
 - Unity UI intake, snapshot contract, smaller-call fallback 문구가 바뀌었다면 layout snapshot keyword check를 실행합니다.
 - plan template, example, candidate promotion rule, validator가 바뀌었다면 mockup layout plan schema check를 실행합니다.
 - discoverability나 스킬 작동 트리거 문구가 바뀌었다면 trigger keyword check를 실행합니다.
@@ -54,6 +56,7 @@ Use this checklist when preparing a tagged release for this repository.
 
 ```powershell
 python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.py D:\UnityUICreater\unity-mcp-ui-layout
+bash D:/UnityUICreater/tests/agent_runbook_keywords.sh
 bash D:/UnityUICreater/tests/layout_snapshot_keywords.sh
 bash D:/UnityUICreater/tests/mockup_layout_plan_schema.sh
 bash D:/UnityUICreater/tests/trigger_keywords.sh

--- a/tests/agent_runbook_keywords.sh
+++ b/tests/agent_runbook_keywords.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+runbook="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/agent-runbook.md")"
+skill_body="$(cat "$ROOT_DIR/unity-mcp-ui-layout/SKILL.md")"
+references_index="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/README.md")"
+root_readme="$(cat "$ROOT_DIR/README.md")"
+maintenance_docs="$(
+  cat "$ROOT_DIR/MAINTENANCE.md"
+  printf '\n'
+  cat "$ROOT_DIR/RELEASE_CHECKLIST.md"
+)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local scope="$3"
+
+  if ! grep -Fqi "$needle" <<<"$haystack"; then
+    printf 'Missing agent-runbook phrase in %s: %s\n' "$scope" "$needle" >&2
+    return 1
+  fi
+}
+
+assert_contains "$runbook" "Agent Execution Runbook" "runbook"
+assert_contains "$runbook" "Name the trigger" "runbook"
+assert_contains "$runbook" "Classify the task" "runbook"
+assert_contains "$runbook" "Gather Unity state" "runbook"
+assert_contains "$runbook" "Plan hierarchy before objects" "runbook"
+assert_contains "$runbook" "Review raster candidates" "runbook"
+assert_contains "$runbook" "Promote only accepted items" "runbook"
+assert_contains "$runbook" "Build Mode Notes" "runbook"
+assert_contains "$runbook" "Repair Mode Notes" "runbook"
+assert_contains "$runbook" "Structured Export Input Notes" "runbook"
+assert_contains "$runbook" "Raster-Only Mockup Input Notes" "runbook"
+assert_contains "$runbook" "Design-Token Input Notes" "runbook"
+assert_contains "$runbook" "Final Response Checklist" "runbook"
+assert_contains "$runbook" "assumptions and unresolved risks" "runbook"
+
+assert_contains "$skill_body" "references/agent-runbook.md" "skill body"
+assert_contains "$references_index" "agent-runbook.md" "references index"
+assert_contains "$root_readme" "agent-runbook.md" "root README"
+assert_contains "$maintenance_docs" "agent runbook keyword checks" "maintenance docs"

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -174,6 +174,7 @@ Do not call the task done until every applicable check below passes:
 
 ### First Stop
 
+- `references/agent-runbook.md`
 - `references/layout-checklist.md`
 - `references/layout-snapshot-contract.md`
 - `references/common-failures.md`

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -6,6 +6,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 
 ## Core Guidance
 
+- `agent-runbook.md` - gives the agent-facing operating sequence after the skill triggers, including mode notes and final response checklist.
 - `layout-checklist.md`
 - `layout-snapshot-contract.md` - defines the ideal Unity UI layout snapshot MCP contract and smaller-call fallback before existing UI edits.
 - `image-to-layout.md` - includes mockup-to-layer-to-tree workflow, candidate item ledger guidance, item rect mapping, and the asset-RAG fallback contract for when `unity-resource-rag` is unavailable or low-confidence.

--- a/unity-mcp-ui-layout/references/agent-runbook.md
+++ b/unity-mcp-ui-layout/references/agent-runbook.md
@@ -1,0 +1,67 @@
+# Agent Execution Runbook
+
+Use this runbook after the skill triggers and before editing Unity UI. It is the operating sequence for the agent. Keep deeper rule lookup in the linked reference docs.
+
+## Operating Sequence
+
+1. **Name the trigger.** Say why this skill applies: mockup-to-UI, UI 시안, prefab creation, layout repair, structured export, design tokens, safe area, text overflow, or shared prefab reuse.
+2. **Classify the task.** Choose UI stack, change mode, design source, and asset strategy before editing.
+3. **Gather Unity state.** Capture a layout snapshot or equivalent smaller-call evidence: active UI root, UI stack, root layout owners, screenshot frame, and console state.
+4. **Plan hierarchy before objects.** For mockups, produce a layer-to-Transform or layer-to-RectTransform tree before creating or moving UI objects.
+5. **Review raster candidates.** If raster item analysis is used, produce candidate item ledger decisions before item rect planning.
+6. **Promote only accepted items.** Record item-level UI rects only for accepted runtime or repeated items. Held candidates remain notes. Rejected candidates must not create Unity objects, prefab children, or crops.
+7. **Build or repair in slices.** Work root shell, major regions, one reusable block or region, then polish. Verify after structural slices.
+8. **Verify before final response.** Use screenshot, alternate aspect ratio, text behavior, console state, and shared-asset checks where applicable.
+9. **Report evidence.** Tell the user what assumptions were made, what artifacts were produced, which screenshots or checks were used, and what residual risks remain.
+
+## Build Mode Notes
+
+- Create the root shell before leaf widgets.
+- Establish `CanvasScaler`, safe-area owner, root regions, and scroll owner before content details.
+- Promote repeated structures into reusable prefabs or layout blocks when repetition is real.
+- Use `templates/mockup-layout-plan.yaml` when the plan needs stable sections across layer tree, candidate ledger, item rects, crops, and verification targets.
+
+## Repair Mode Notes
+
+- Inspect the current parent chain before editing.
+- Keep the repair bounded to the named region unless parent structure is the real cause.
+- Preserve existing style unless it directly causes the layout failure.
+- Prefer variants, wrappers, or local overrides before direct shared-base edits for one-screen requests.
+- Explain scope expansion before rebuilding a region that was requested as a small repair.
+
+## Structured Export Input Notes
+
+- Treat Stitch HTML/CSS, Figma node-tree JSON, component trees, or similar exports as hierarchy sources.
+- Normalize export nodes into semantic containers, repeated units, overlays, and layout ownership rules.
+- Do not let raster candidate detection override structured export hierarchy.
+- Use screenshots or mockups as composition validation, not as the hierarchy source, when a structured export is present.
+
+## Raster-Only Mockup Input Notes
+
+- Use the mockup native resolution when no explicit target resolution exists.
+- Run the layer-to-tree pass before object creation.
+- Keep candidate item ledger output advisory until review decisions are recorded.
+- Use item rects for accepted runtime leaves or repeated items only.
+- Keep decorative baked regions whole unless interaction, animation, dynamic content, adaptive layout, or reuse requires splitting.
+
+## Design-Token Input Notes
+
+- Read `DESIGN.md`, design tokens, Tailwind theme values, or equivalent sources before styling.
+- Treat machine-readable tokens as the style contract and prose as application intent.
+- Keep design-token styling separate from hierarchy ownership decisions.
+- Preserve colors, typography, spacing, radius, component states, and readable contrast where the source defines them.
+
+## Final Response Checklist
+
+In the final response after using the skill, include:
+
+- trigger reason and chosen UI stack
+- change mode: build or repair
+- design source split: structured export, raster mockup, design tokens, or none
+- layout snapshot or fallback intake status
+- produced planning artifacts: layer tree, candidate ledger, item rect plan, asset crop plan, or template path
+- implementation scope: regions, prefabs, variants, wrappers, or assets touched
+- verification evidence: screenshots, alternate aspect, text checks, console state, shared-asset checks
+- assumptions and unresolved risks
+
+If a check could not be run, state that directly with the reason.


### PR DESCRIPTION
## Summary
- add `agent-runbook.md` with the skill operating sequence for live Unity UI tasks
- cover build mode, repair mode, structured export input, raster-only mockup input, and design-token input notes
- add a final response checklist for assumptions, artifacts, verification, and risks
- link the runbook from `SKILL.md`, the root README, and the references index
- add `tests/agent_runbook_keywords.sh` for coverage

Closes #70.

## Validation
- bash -n tests/agent_runbook_keywords.sh && bash tests/agent_runbook_keywords.sh
- bash -n tests/mockup_layout_plan_schema.sh && bash tests/mockup_layout_plan_schema.sh
- bash -n tests/layout_snapshot_keywords.sh && bash tests/layout_snapshot_keywords.sh
- bash -n tests/trigger_keywords.sh && bash tests/trigger_keywords.sh
- bash -n tests/layer_tree_keywords.sh && bash tests/layer_tree_keywords.sh
- bash -n tests/item_rect_keywords.sh && bash tests/item_rect_keywords.sh
- bash -n tests/item_candidate_keywords.sh && bash tests/item_candidate_keywords.sh
- python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py unity-mcp-ui-layout
- ruby -e 'require "yaml"; YAML.load_file("unity-mcp-ui-layout/agents/openai.yaml"); YAML.load_file("templates/mockup-layout-plan.yaml"); YAML.load_file("examples/mockup-layout-plan-prefab-example.yaml"); puts "ok"'\n- git diff --check\n\nNote: shellcheck is not installed in this environment.