### PR TITLE
[codex] Clarify review gates and assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project follows a lightweight documentation-focused release flow.
 - Added layout snapshot keyword validation for the snapshot contract, skill entry point, agent metadata, MCP recipes, review checks, and maintenance docs
 - Added a mockup layout plan template, filled prefab-from-mockup example, and schema validator for layer tree, candidate ledger, item rect, asset crop, and verification target planning
 - Added an agent execution runbook with trigger naming, task classification, build/repair/input-mode notes, and final response checklist
+- Added review gate and assumption guidance for hard blockers, soft assumptions, no-human-review fallback, candidate decision examples, and final reporting
 
 ### Added / 추가
 
@@ -19,6 +20,7 @@ This project follows a lightweight documentation-focused release flow.
 - snapshot contract, skill entry point, agent metadata, MCP recipe, review check, maintenance docs를 확인하는 layout snapshot keyword validation 추가
 - layer tree, candidate ledger, item rect, asset crop, verification target planning을 위한 mockup layout plan template, prefab-from-mockup 예제, schema validator 추가
 - trigger naming, task classification, build/repair/input-mode note, final response checklist를 포함한 agent execution runbook 추가
+- hard blocker, soft assumption, no-human-review fallback, candidate decision example, final reporting을 다루는 review gate 및 assumption 지침 추가
 
 ## v0.6.0 - 2026-06-26
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -26,6 +26,7 @@ python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.
 bash D:/UnityUICreater/tests/agent_runbook_keywords.sh
 bash D:/UnityUICreater/tests/layout_snapshot_keywords.sh
 bash D:/UnityUICreater/tests/mockup_layout_plan_schema.sh
+bash D:/UnityUICreater/tests/review_gates_keywords.sh
 bash D:/UnityUICreater/tests/trigger_keywords.sh
 bash D:/UnityUICreater/tests/layer_tree_keywords.sh
 bash D:/UnityUICreater/tests/item_rect_keywords.sh
@@ -70,6 +71,7 @@ flowchart TD
 - agent runbook keyword checks still cover trigger naming, task classification, Unity-state intake, input-mode notes, and final response checklist
 - layout snapshot keyword checks still cover active root, UI stack, screenshot frame, fallback calls, and console state wording
 - mockup layout plan schema checks still cover required sections and accept/hold/reject promotion rules
+- review gates keyword checks still cover hard blockers, soft assumptions, no-human-review fallback, and candidate decision reporting
 - trigger keyword checks still cover mockup/image-to-prefab request wording
 - layer/tree keyword checks still cover mockup-to-Transform hierarchy wording
 - item rect keyword checks still cover mockup item sizing and crop-plan wording
@@ -82,6 +84,7 @@ flowchart TD
 - agent runbook keyword check가 trigger naming, task classification, Unity-state intake, input-mode note, final response checklist를 계속 커버하는지 확인합니다.
 - layout snapshot keyword check가 active root, UI stack, screenshot frame, fallback call, console state 문구를 계속 커버하는지 확인합니다.
 - mockup layout plan schema check가 required section과 accept/hold/reject promotion rule을 계속 커버하는지 확인합니다.
+- review gates keyword check가 hard blocker, soft assumption, no-human-review fallback, candidate decision reporting을 계속 커버하는지 확인합니다.
 - mockup/image-to-prefab 요청 표현을 trigger keyword check가 계속 커버하는지 확인합니다.
 - mockup-to-Transform hierarchy 표현을 layer/tree keyword check가 계속 커버하는지 확인합니다.
 - mockup item sizing과 crop-plan 표현을 item rect keyword check가 계속 커버하는지 확인합니다.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ tests/
   agent_runbook_keywords.sh
   layout_snapshot_keywords.sh
   mockup_layout_plan_schema.sh
+  review_gates_keywords.sh
   trigger_keywords.sh
   layer_tree_keywords.sh
   item_rect_keywords.sh
@@ -251,6 +252,7 @@ Run the focused checks when release prep or discoverability wording changes.
 bash tests/agent_runbook_keywords.sh
 bash tests/layout_snapshot_keywords.sh
 bash tests/mockup_layout_plan_schema.sh
+bash tests/review_gates_keywords.sh
 bash tests/trigger_keywords.sh
 bash tests/layer_tree_keywords.sh
 bash tests/item_rect_keywords.sh

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -32,6 +32,7 @@ Use this checklist when preparing a tagged release for this repository.
 - run agent runbook keyword checks when the agent operating sequence, mode notes, or final response checklist changed
 - run layout snapshot keyword checks when Unity UI intake, snapshot contracts, or smaller-call fallback wording changed
 - run mockup layout plan schema checks when the plan template, example, candidate promotion rules, or validator changed
+- run review gates keyword checks when hard blocker, soft assumption, no-human-review, or candidate decision reporting guidance changed
 - run trigger keyword checks when discoverability or skill activation wording changed
 - run layer/tree keyword checks when mockup decomposition or hierarchy guidance changed
 - run item rect keyword checks when mockup item sizing, source rect, or crop-plan guidance changed
@@ -44,6 +45,7 @@ Use this checklist when preparing a tagged release for this repository.
 - agent operating sequence, mode note, final response checklist가 바뀌었다면 agent runbook keyword check를 실행합니다.
 - Unity UI intake, snapshot contract, smaller-call fallback 문구가 바뀌었다면 layout snapshot keyword check를 실행합니다.
 - plan template, example, candidate promotion rule, validator가 바뀌었다면 mockup layout plan schema check를 실행합니다.
+- hard blocker, soft assumption, no-human-review, candidate decision reporting 지침이 바뀌었다면 review gates keyword check를 실행합니다.
 - discoverability나 스킬 작동 트리거 문구가 바뀌었다면 trigger keyword check를 실행합니다.
 - mockup decomposition이나 hierarchy 지침이 바뀌었다면 layer/tree keyword check를 실행합니다.
 - mockup item sizing, source rect, crop-plan 지침이 바뀌었다면 item rect keyword check를 실행합니다.
@@ -59,6 +61,7 @@ python C:\Users\user\.codex\skills\.system\skill-creator\scripts\quick_validate.
 bash D:/UnityUICreater/tests/agent_runbook_keywords.sh
 bash D:/UnityUICreater/tests/layout_snapshot_keywords.sh
 bash D:/UnityUICreater/tests/mockup_layout_plan_schema.sh
+bash D:/UnityUICreater/tests/review_gates_keywords.sh
 bash D:/UnityUICreater/tests/trigger_keywords.sh
 bash D:/UnityUICreater/tests/layer_tree_keywords.sh
 bash D:/UnityUICreater/tests/item_rect_keywords.sh

--- a/tests/review_gates_keywords.sh
+++ b/tests/review_gates_keywords.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+gate_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/review-gates-and-assumptions.md")"
+skill_body="$(cat "$ROOT_DIR/unity-mcp-ui-layout/SKILL.md")"
+mockup_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/mockup-decomposition.md")"
+review_doc="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/review-checks.md")"
+runbook="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/agent-runbook.md")"
+references_index="$(cat "$ROOT_DIR/unity-mcp-ui-layout/references/README.md")"
+maintenance_docs="$(
+  cat "$ROOT_DIR/MAINTENANCE.md"
+  printf '\n'
+  cat "$ROOT_DIR/RELEASE_CHECKLIST.md"
+)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local scope="$3"
+
+  if ! grep -Fqi "$needle" <<<"$haystack"; then
+    printf 'Missing review-gates phrase in %s: %s\n' "$scope" "$needle" >&2
+    return 1
+  fi
+}
+
+assert_contains "$gate_doc" "Review Gates And Assumptions" "review gates doc"
+assert_contains "$gate_doc" "Hard Blockers: Ask Before Editing" "review gates doc"
+assert_contains "$gate_doc" "Unknown UI stack in a mixed-stack project" "review gates doc"
+assert_contains "$gate_doc" "Destructive shared-base change" "review gates doc"
+assert_contains "$gate_doc" "Soft Ambiguities: Proceed With Named Assumptions" "review gates doc"
+assert_contains "$gate_doc" "Mockup native resolution fallback" "review gates doc"
+assert_contains "$gate_doc" "Layout-only placeholder assets" "review gates doc"
+assert_contains "$gate_doc" "Candidate Ledger Review States" "review gates doc"
+assert_contains "$gate_doc" "Accepted Candidate" "review gates doc"
+assert_contains "$gate_doc" "Held Candidate" "review gates doc"
+assert_contains "$gate_doc" "Rejected Candidate" "review gates doc"
+assert_contains "$gate_doc" "When No Human Review Is Available" "review gates doc"
+assert_contains "$gate_doc" "must not create Unity objects, prefab children, or crop assets" "review gates doc"
+assert_contains "$gate_doc" "Final Response Requirements" "review gates doc"
+
+assert_contains "$skill_body" "references/review-gates-and-assumptions.md" "skill body"
+assert_contains "$mockup_doc" "review-gates-and-assumptions.md" "mockup decomposition"
+assert_contains "$mockup_doc" "If no human review is available" "mockup decomposition"
+assert_contains "$review_doc" "review-gates-and-assumptions.md" "review checks"
+assert_contains "$review_doc" "Assumption And Review Gate Check" "review checks"
+assert_contains "$runbook" "review-gates-and-assumptions.md" "agent runbook"
+assert_contains "$references_index" "review-gates-and-assumptions.md" "references index"
+assert_contains "$maintenance_docs" "review gates keyword checks" "maintenance docs"

--- a/unity-mcp-ui-layout/SKILL.md
+++ b/unity-mcp-ui-layout/SKILL.md
@@ -179,6 +179,7 @@ Do not call the task done until every applicable check below passes:
 - `references/layout-snapshot-contract.md`
 - `references/common-failures.md`
 - `references/review-checks.md`
+- `references/review-gates-and-assumptions.md`
 - `references/scroll-view-patterns.md`
 - `references/ui-change-modes.md`
 

--- a/unity-mcp-ui-layout/references/README.md
+++ b/unity-mcp-ui-layout/references/README.md
@@ -29,6 +29,7 @@ Use it when `SKILL.md` points you here for deeper guidance.
 - `text-layout-rules.md`
 - `common-failures.md`
 - `review-checks.md`
+- `review-gates-and-assumptions.md` - explains hard blockers, soft assumptions, candidate review states, no-human-review fallback, and final reporting.
 - `scroll-view-patterns.md`
 - `design-system-intake.md`
 - `design-token-to-unity.md`

--- a/unity-mcp-ui-layout/references/agent-runbook.md
+++ b/unity-mcp-ui-layout/references/agent-runbook.md
@@ -8,11 +8,12 @@ Use this runbook after the skill triggers and before editing Unity UI. It is the
 2. **Classify the task.** Choose UI stack, change mode, design source, and asset strategy before editing.
 3. **Gather Unity state.** Capture a layout snapshot or equivalent smaller-call evidence: active UI root, UI stack, root layout owners, screenshot frame, and console state.
 4. **Plan hierarchy before objects.** For mockups, produce a layer-to-Transform or layer-to-RectTransform tree before creating or moving UI objects.
-5. **Review raster candidates.** If raster item analysis is used, produce candidate item ledger decisions before item rect planning.
-6. **Promote only accepted items.** Record item-level UI rects only for accepted runtime or repeated items. Held candidates remain notes. Rejected candidates must not create Unity objects, prefab children, or crops.
-7. **Build or repair in slices.** Work root shell, major regions, one reusable block or region, then polish. Verify after structural slices.
-8. **Verify before final response.** Use screenshot, alternate aspect ratio, text behavior, console state, and shared-asset checks where applicable.
-9. **Report evidence.** Tell the user what assumptions were made, what artifacts were produced, which screenshots or checks were used, and what residual risks remain.
+5. **Resolve gates and assumptions.** Use `review-gates-and-assumptions.md` to decide whether to ask the user or proceed with named assumptions.
+6. **Review raster candidates.** If raster item analysis is used, produce candidate item ledger decisions before item rect planning.
+7. **Promote only accepted items.** Record item-level UI rects only for accepted runtime or repeated items. Held candidates remain notes. Rejected candidates must not create Unity objects, prefab children, or crops.
+8. **Build or repair in slices.** Work root shell, major regions, one reusable block or region, then polish. Verify after structural slices.
+9. **Verify before final response.** Use screenshot, alternate aspect ratio, text behavior, console state, and shared-asset checks where applicable.
+10. **Report evidence.** Tell the user what assumptions were made, what artifacts were produced, which screenshots or checks were used, and what residual risks remain.
 
 ## Build Mode Notes
 
@@ -62,6 +63,7 @@ In the final response after using the skill, include:
 - produced planning artifacts: layer tree, candidate ledger, item rect plan, asset crop plan, or template path
 - implementation scope: regions, prefabs, variants, wrappers, or assets touched
 - verification evidence: screenshots, alternate aspect, text checks, console state, shared-asset checks
+- candidate decisions by accept, hold, and reject when a candidate ledger was used
 - assumptions and unresolved risks
 
 If a check could not be run, state that directly with the reason.

--- a/unity-mcp-ui-layout/references/mockup-decomposition.md
+++ b/unity-mcp-ui-layout/references/mockup-decomposition.md
@@ -3,6 +3,7 @@
 Use this guide when a mockup, screenshot, design image, or UI 시안 exists and you need to decide which regions should stay as one asset, which should become reusable layout blocks or Unity UI prefabs, and which should be separated into interactive UI elements.
 
 Use `../../templates/mockup-layout-plan.yaml` when the decomposition needs a concise machine-readable artifact for layer tree, candidate review, item rect, asset crop, and verification target decisions.
+Use `review-gates-and-assumptions.md` when deciding whether an ambiguity should pause for user confirmation or proceed with named assumptions.
 
 ## Goal
 
@@ -53,6 +54,8 @@ For each candidate, record:
 Use accept/hold/reject instead of silently deleting uncertain candidates. Accepted candidates may become item-level UI rect entries. Held candidates remain review notes. Rejected candidates should not create Unity objects or mockup-derived crops.
 
 The template policy is strict: accepted candidates may become item rect entries after parent ownership and split reason are reviewed, held candidates remain notes, and rejected candidates must not create Unity objects, prefab children, or crops.
+
+If no human review is available, accept only high-confidence candidates with a clear parent hint, split reason, and runtime or reuse evidence. Keep low-confidence or decorative candidates held, build parent structure first, and avoid creating crop assets from uncertain candidates.
 
 For each runtime or repeated item, record:
 

--- a/unity-mcp-ui-layout/references/review-checks.md
+++ b/unity-mcp-ui-layout/references/review-checks.md
@@ -4,6 +4,8 @@ Use this guide at the end of a `unity-mcp` UI task before calling the result com
 
 This is a final review pass, not a discovery checklist. The goal is to catch issues that often survive basic implementation.
 
+For ambiguity handling and candidate review policy, use `review-gates-and-assumptions.md`.
+
 ## 0. Layout Snapshot Intake Check
 
 Use this check when the task edited an existing Unity UI screen or built mockup-driven UI inside an existing scene.
@@ -116,6 +118,20 @@ Ask:
 - If a structured export also existed, did the export still own hierarchy while the raster candidate ledger stayed advisory?
 
 If candidate over-decomposition is present, reject or hold the candidate and return to layer ownership before item sizing.
+
+## 4D. Assumption And Review Gate Check
+
+Use this check when ambiguity was handled during mockup-driven UI work.
+
+Ask:
+
+- Were hard blockers confirmed before editing, such as unknown UI stack in a mixed-stack project, unclear target screen, destructive shared-base changes, ambiguous repair versus rebuild scope, or missing required runtime behavior?
+- Were soft ambiguities handled with named assumptions, such as mockup native resolution fallback, layout-only placeholder assets, non-destructive spacing choices, or content-length headroom?
+- If no human review was available, were low-confidence candidates held while parent structure was built first?
+- Were held and rejected candidates prevented from creating Unity objects, prefab children, or crop assets?
+- Did the final response summarize assumptions, candidate decisions, and remaining review risks?
+
+If assumptions or candidate decisions are missing from the final report, add them before calling the task complete.
 
 ## 5. Asset Granularity Check
 

--- a/unity-mcp-ui-layout/references/review-gates-and-assumptions.md
+++ b/unity-mcp-ui-layout/references/review-gates-and-assumptions.md
@@ -1,0 +1,128 @@
+# Review Gates And Assumptions
+
+Use this guide when mockup-driven UI work has ambiguity. The goal is to avoid two failure modes: blocking every small task, or silently turning uncertain visual guesses into real Unity objects, prefab children, or crop assets.
+
+## Decision Rule
+
+- Ask the user before editing when the ambiguity can change the target screen, UI stack, shared asset contract, or destructive scope.
+- Continue with named assumptions when the ambiguity is local, reversible, and does not create shared assets or crops from uncertain candidates.
+- Record every assumption and review decision in the final response.
+
+## Hard Blockers: Ask Before Editing
+
+Pause for confirmation when any of these are true:
+
+- **Unknown UI stack in a mixed-stack project.** Example: both `Canvas` and `UIDocument` are active, and the user did not identify the target stack.
+- **Unclear target screen or prefab root.** Example: multiple inventory screens are open and the request only says "fix this UI."
+- **Destructive shared-base change.** Example: the repair would directly edit a common prefab, sprite, material, or TMP style used by other screens.
+- **Ambiguous repair versus rebuild scope.** Example: a bounded alignment fix appears to require replacing the parent layout system.
+- **Missing required runtime behavior.** Example: a mockup element may be decorative or clickable, and creating it as a button would change behavior.
+
+Hard blocker response pattern:
+
+```text
+I need one confirmation before editing: this project has both UGUI and UI Toolkit roots, and the request does not identify which stack owns the target screen. Which UI stack should I modify?
+```
+
+## Soft Ambiguities: Proceed With Named Assumptions
+
+Proceed with an explicit assumption when the choice is local and reversible:
+
+- **Mockup native resolution fallback.** If no target resolution is provided, use the image's native resolution as the planning frame.
+- **Layout-only placeholder assets.** If asset retrieval is unavailable or low-confidence, use placeholders and mark visuals provisional.
+- **Non-destructive local spacing choice.** If two parent-owned spacing interpretations are close, choose the one that preserves anchors and layout groups.
+- **Unknown final copy length.** Use realistic text headroom and note that final localization still needs a content pass.
+- **No human candidate review available.** Build parent structure first, accept only high-confidence runtime/reuse candidates with evidence, keep low-confidence candidates held, and avoid creating crop assets from uncertain candidates.
+
+Soft assumption response pattern:
+
+```text
+Proceeding with the mockup's native 1440x2560 resolution as the planning frame because no target resolution was provided. I will keep asset choices provisional and avoid shared-base edits.
+```
+
+Soft assumption example:
+
+```text
+Assumption: asset retrieval is unavailable, so this pass stays layout-only. I will use placeholders, avoid shared-base edits, and mark visuals provisional until project assets are reviewed.
+```
+
+## Candidate Ledger Review States
+
+Use exactly these states:
+
+- `accept`: enough evidence exists to promote the candidate into item-level UI rect planning.
+- `hold`: evidence is incomplete or no review is available; keep it as a note only.
+- `reject`: evidence shows the candidate should not become a runtime object, prefab child, or crop.
+
+Accepted candidate evidence should name:
+
+- parent hint from the layer tree
+- split reason tied to interaction, dynamic data, state, animation, adaptive layout, reuse, or import boundary
+- visible evidence such as containment, repeated shape, shared baseline, icon/text cluster, strong contrast boundary, panel boundary, or explicit user hint
+- fit or crop intent if the candidate will become a rect or crop
+
+Held candidates remain review notes and must not create Unity objects, prefab children, or crop assets.
+Rejected candidates must not create Unity objects, prefab children, or crop assets.
+
+## Concrete Candidate Examples
+
+### Accepted Candidate
+
+```yaml
+candidate_id: "candidate/RewardCard/Icon"
+confidence_band: "high"
+evidence:
+  - "dynamic reward content"
+  - "centered icon cluster"
+  - "strong contrast boundary"
+parent_hint: "RewardPopupRoot/RewardCard"
+review_decision: "accept"
+decision_note: "Promote to item rect because the icon changes at runtime and belongs to the RewardCard prefab."
+```
+
+### Held Candidate
+
+```yaml
+candidate_id: "candidate/RewardCard/OuterGlow"
+confidence_band: "medium"
+evidence:
+  - "soft decorative boundary"
+parent_hint: "RewardPopupRoot/RewardCard"
+review_decision: "hold"
+decision_note: "Keep as review note. It may be baked into the card background, so do not create a prefab child or crop yet."
+```
+
+### Rejected Candidate
+
+```yaml
+candidate_id: "candidate/RewardCard/InnerHighlightLine"
+confidence_band: "medium"
+evidence:
+  - "decorative separator"
+parent_hint: "RewardPopupRoot/RewardCard"
+review_decision: "reject"
+decision_note: "Reject as a separate item. It stays inside the baked card background and must not create a Unity object or crop."
+```
+
+## When No Human Review Is Available
+
+If no human review is available during the current run:
+
+1. Build the parent-owned layer tree first.
+2. Accept only high-confidence candidates with a clear parent hint, split reason, and runtime/reuse evidence.
+3. Hold low-confidence or decorative candidates.
+4. Do not create crop assets from held or rejected candidates.
+5. Prefer placeholders or existing assets over mockup-derived crops when evidence is uncertain.
+6. Report which candidates were accepted, held, and rejected in the final response.
+
+## Final Response Requirements
+
+When assumptions or candidate review decisions affected the work, report:
+
+- hard blockers that were confirmed, or that no hard blockers remained
+- soft assumptions used
+- candidate counts by `accept`, `hold`, and `reject`
+- any accepted candidate promoted into item rect planning
+- held candidates that stayed notes
+- rejected candidates that were prevented from creating objects, prefab children, or crops
+- remaining risks that need user or art review


### PR DESCRIPTION
## Summary
- add `review-gates-and-assumptions.md` for hard blockers, soft assumptions, candidate review states, no-human-review fallback, and final reporting
- link the guidance from `SKILL.md`, mockup decomposition, review checks, the agent runbook, and the references index
- add final review checks for assumptions, human review gaps, and held/rejected candidate behavior
- add `tests/review_gates_keywords.sh` for coverage

Closes #71.

## Validation
- bash -n tests/review_gates_keywords.sh && bash tests/review_gates_keywords.sh
- bash -n tests/agent_runbook_keywords.sh && bash tests/agent_runbook_keywords.sh
- bash -n tests/mockup_layout_plan_schema.sh && bash tests/mockup_layout_plan_schema.sh
- bash -n tests/layout_snapshot_keywords.sh && bash tests/layout_snapshot_keywords.sh
- bash -n tests/trigger_keywords.sh && bash tests/trigger_keywords.sh
- bash -n tests/layer_tree_keywords.sh && bash tests/layer_tree_keywords.sh
- bash -n tests/item_rect_keywords.sh && bash tests/item_rect_keywords.sh
- bash -n tests/item_candidate_keywords.sh && bash tests/item_candidate_keywords.sh
- python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py unity-mcp-ui-layout
- ruby -e 'require "yaml"; YAML.load_file("unity-mcp-ui-layout/agents/openai.yaml"); YAML.load_file("templates/mockup-layout-plan.yaml"); YAML.load_file("examples/mockup-layout-plan-prefab-example.yaml"); puts "ok"'\n- git diff --check\n\nNote: shellcheck is not installed in this environment.